### PR TITLE
feat:더미데이터를 사용한 챌린지 상세 페이지 일부 구현

### DIFF
--- a/src/app/(user)/challenges/[challengeId]/page.jsx
+++ b/src/app/(user)/challenges/[challengeId]/page.jsx
@@ -1,6 +1,190 @@
-import Container from "@/components/container/PageContainer";
-import React from "react";
+"use client";
 
-export default function page() {
-  return <Container>챌린지 상세 페이지</Container>;
+import React, { useState } from "react";
+import ChallengeCard from "@/components/card/Card";
+import CallengeContainerd from "@/app/(user)/challenges/_components/challengeCard/CallengeContainer";
+import Image from "next/image";
+import userIcon from "@/assets/img/profile_member.svg";
+import RankingListItem from "@/components/list/RankingListItem";
+import arrowRight from "@/assets/icon/ic_arrow_right.svg";
+import arrowLeft from "@/assets/icon/ic_arrow_left.svg";
+
+export default function ChallengeDetailPage() {
+  const dummyChallenge = {
+    title: "Next.js - App Router : Routing Fundamentals",
+    type: "nextjs",
+    category: "officialdoc",
+    deadline: "2025-06-01",
+    participants: "15/20",
+    description:
+      "Next.js App Router 공식 문서 중 Routing Fundamentals 내용입니다! 라우팅에 따른 폴더와 파일이 구성되는 법칙과 컨벤션 등에 대해 공부할 수 있을 것 같아요~! 다들 챌린지 많이 참여해 주세요 :)",
+    createdBy: {
+      nickname: "dev_sungbin",
+      profileImage: userIcon,
+    },
+  };
+
+  const [rankingData, setRankingData] = useState([
+    {
+      rank: 1,
+      userName: "홍길동",
+      userRole: "전문가",
+      likes: 1234,
+      isLiked: false,
+      workId: 101,
+    },
+    {
+      rank: 2,
+      userName: "김철수",
+      userRole: "전문가",
+      likes: 456,
+      isLiked: true,
+      workId: 102,
+    },
+    {
+      rank: 3,
+      userName: "이영희",
+      userRole: "전문가",
+      likes: 789,
+      isLiked: false,
+      workId: 103,
+    },
+    {
+      rank: 4,
+      userName: "박민수",
+      userRole: "전문가",
+      likes: 321,
+      isLiked: false,
+      workId: 104,
+    },
+    {
+      rank: 5,
+      userName: "최지우",
+      userRole: "전문가",
+      likes: 654,
+      isLiked: true,
+      workId: 105,
+    },
+    {
+      rank: 6,
+      userName: "조성빈",
+      userRole: "전문가",
+      likes: 777,
+      isLiked: false,
+      workId: 106,
+    },
+  ]);
+
+  const itemsPerPage = 5;
+  const totalPages = Math.ceil(rankingData.length / itemsPerPage);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const handleToggleLike = (index) => {
+    setRankingData((prev) =>
+      prev.map((item, i) =>
+        i === index
+          ? {
+              ...item,
+              isLiked: !item.isLiked,
+              likes: item.isLiked ? item.likes - 1 : item.likes + 1,
+            }
+          : item,
+      ),
+    );
+  };
+
+  const goToPrevPage = () => {
+    if (currentPage > 1) setCurrentPage((prev) => prev - 1);
+  };
+
+  const goToNextPage = () => {
+    if (currentPage < totalPages) setCurrentPage((prev) => prev + 1);
+  };
+
+  const startIndex = (currentPage - 1) * itemsPerPage;
+  const currentItems = rankingData.slice(startIndex, startIndex + itemsPerPage);
+
+  return (
+    <main className="flex flex-col items-center px-4 pt-12">
+      <div className="w-full max-w-sm">
+        <ChallengeCard
+          title={dummyChallenge.title}
+          type={dummyChallenge.type}
+          category={dummyChallenge.category}
+          deadline={dummyChallenge.deadline}
+          participants={dummyChallenge.participants}
+          variant="simple"
+        />
+      </div>
+
+      {/* 설명 */}
+      <section className="mt-6 w-full max-w-sm text-gray-800">
+        <p className="text-base leading-relaxed whitespace-pre-line">
+          {dummyChallenge.description}
+        </p>
+      </section>
+
+      {/* 작성자 정보 */}
+      <section className="mt-6 flex w-full max-w-sm items-center gap-2">
+        <Image
+          src={dummyChallenge.createdBy.profileImage}
+          alt="작성자 프로필"
+          width={32}
+          height={32}
+          className="rounded-full"
+        />
+        <span className="text-sm font-medium text-gray-700">
+          {dummyChallenge.createdBy.nickname}
+        </span>
+      </section>
+
+      {/* 도전하기 버튼 */}
+      <section className="mt-8 w-full max-w-sm">
+        <CallengeContainerd height="h-auto" type="slim" />
+      </section>
+
+      {/* 참여현황 리스트 */}
+      <section className="mt-10 w-full max-w-sm rounded-xl border-2 border-gray-800 bg-white">
+        <div className="flex items-center justify-between px-4 py-3">
+          <h3 className="text-base font-semibold text-gray-800">참여현황</h3>
+          <div className="flex items-center gap-2">
+            <span className="rounded-full bg-gray-50 px-3 py-0.5 text-sm text-gray-800">
+              {currentPage} / {totalPages}
+            </span>
+            <button onClick={goToPrevPage} disabled={currentPage === 1}>
+              <Image
+                src={arrowLeft}
+                alt="이전"
+                width={20}
+                height={20}
+                className={`${currentPage === 1 ? "opacity-30" : ""}`}
+              />
+            </button>
+            <button
+              onClick={goToNextPage}
+              disabled={currentPage === totalPages}
+            >
+              <Image
+                src={arrowRight}
+                alt="다음"
+                width={20}
+                height={20}
+                className={`${currentPage === totalPages ? "opacity-30" : ""}`}
+              />
+            </button>
+          </div>
+        </div>
+
+        <div className="px-4">
+          {currentItems.map((item, index) => (
+            <RankingListItem
+              key={item.rank}
+              item={item}
+              toggleLike={() => handleToggleLike(startIndex + index)}
+            />
+          ))}
+        </div>
+      </section>
+    </main>
+  );
 }

--- a/src/components/card/Card.jsx
+++ b/src/components/card/Card.jsx
@@ -3,48 +3,62 @@ import dropdownIcon from "@/assets/icon/ic_menu.svg";
 import clockIcon from "@/assets/icon/ic_clock.svg";
 import usersIcon from "@/assets/icon/ic_person.svg";
 import { typeChipMap, categoryChipMap } from "../chip/chipMaps";
-import ChipCardStatus from "@/components/chip/chipComplete/ChipCardStatus"; // 좌상단 chip
+import ChipCardStatus from "@/components/chip/chipComplete/ChipCardStatus";
 
 export default function ChallengeCard({
-  status,
   title,
   type,
   category,
   deadline,
   participants,
+  status,
+  variant = "full",
 }) {
+  const isSimple = variant === "simple";
+  const hasStatus = !isSimple && status;
+
   return (
-    <div className="flex h-[227px] w-full max-w-[996px] flex-col justify-between rounded-[12px] bg-white p-4 shadow-md sm:h-[262px] sm:max-w-[343px] md:h-[225px] md:max-w-[696px]">
-      <div className="flex items-start justify-between">
-        <ChipCardStatus status={status} />
+    <div
+      className={`flex w-full flex-col ${isSimple ? "" : "rounded-xl bg-white shadow-md"}`}
+    >
+      {/* 상단: 좌측에는 상태칩 또는 제목, 우측에는 드롭다운 */}
+      <div className="flex items-center justify-between">
+        {hasStatus ? (
+          <ChipCardStatus status={status} />
+        ) : (
+          <div className="text-xl font-semibold text-gray-800">{title}</div>
+        )}
         <button>
           <Image src={dropdownIcon} alt="드롭다운" width={24} height={24} />
         </button>
       </div>
 
-      <div className="mt-2 text-[22px] font-semibold text-[var(-gray-400)]">
-        {title}
-      </div>
+      {hasStatus && (
+        <div className="mt-2 text-xl font-semibold text-gray-800">{title}</div>
+      )}
 
       <div className="mt-2 flex flex-wrap gap-2">
-        {typeChipMap[type]}
-        {categoryChipMap[category]}
+        {typeChipMap[type] ?? null}
+        {categoryChipMap[category] ?? null}
       </div>
 
-      <hr className="my-4 border-gray-200" />
-
-      <div className="flex justify-between text-sm text-gray-500">
-        <div className="flex gap-4">
-          <div className="flex items-center gap-1">
-            <Image src={clockIcon} alt="시계" width={16} height={16} />
-            <span>{deadline}</span>
+      {!isSimple && (
+        <>
+          <hr className="my-4 border-gray-200" />
+          <div className="flex justify-between text-sm text-gray-500">
+            <div className="flex gap-4">
+              <div className="flex items-center gap-1">
+                <Image src={clockIcon} alt="시계" width={16} height={16} />
+                <span>{deadline}</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <Image src={usersIcon} alt="사람" width={16} height={16} />
+                <span>{participants}</span>
+              </div>
+            </div>
           </div>
-          <div className="flex items-center gap-1">
-            <Image src={usersIcon} alt="사람" width={16} height={16} />
-            <span>{participants}</span>
-          </div>
-        </div>
-      </div>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 📌 구현한 기능

- 챌린지 상세 페이지 구현
  - 카드 형태의 챌린지 정보 표시 (제목, 태그, 마감일, 참여자 수 등)
  - 챌린지 설명 및 작성자 정보 표시
  - 도전 버튼, 원문 보기 버튼 포함된 CallengeContainerd 컴포넌트 사용
  - 참여현황 리스트 및 좋아요 기능 구현
  - 페이지네이션 기능 (5개씩 렌더링, 화살표로 페이지 전환)

---

## ✨ 주요 UI/UX 요소

- `RankingListItem`에서 좋아요 클릭 시 애니메이션 및 카운트 증가/감소 반영
- 참여현황 상단에 현재 페이지 / 전체 페이지 표시
- 우측 화살표 버튼 2개로 페이지 전환 가능
- 최대 너비 `max-w-sm`으로 모바일 환경 기준 UI 정렬
- border 및 텍스트 스타일 Tailwind 기반 커스터마이징

---

## 🧪 테스트 방법

1. `/challenges/[id]` 경로로 접속
2. 페이지 내부 각 영역이 정상 출력되는지 확인
3. 좋아요 버튼 클릭 시 하트 및 수치 변경 확인
4. 참여현황 하단 유저 리스트가 5개 이상일 때 페이지네이션 확인

---

## 📎 기타 참고 사항

- 실제 데이터 연동은 추후 API 연결 시 적용 예정
- 현재는 더미 데이터로 렌더링됨

---
p.s 지금 상태 매우 안좋아서 코드가 지저분합니다
감안하고 봐주세요...

<img width="709" alt="스크린샷 2025-05-21 오후 5 27 01" src="https://github.com/user-attachments/assets/9b10e214-9776-4f52-85cd-cdd0adc6e460" />
