### PR TITLE
feat:챌린지 상세 페이지 구현

### DIFF
--- a/src/app/(user)/challenges/[challengeId]/page.jsx
+++ b/src/app/(user)/challenges/[challengeId]/page.jsx
@@ -1,78 +1,49 @@
-"use client";
+'use client';
 
-import React, { useState } from "react";
-import ChallengeCard from "@/components/card/Card";
-import ChallengeContainerd from "@/app/(user)/challenges/_components/challengeCard/ChallengeContainer";
-import Image from "next/image";
-import userIcon from "@/assets/img/profile_member.svg";
-import RankingListItem from "@/components/list/RankingListItem";
-import arrowRight from "@/assets/icon/ic_arrow_right.svg";
-import arrowLeft from "@/assets/icon/ic_arrow_left.svg";
+import React, { useState, useEffect } from 'react';
+import Image from 'next/image';
+import ChallengeCard from '@/components/card/Card';
+import ChallengeContainerd from '@/app/(user)/challenges/_components/challengeCard/ChallengeContainer';
+import RankingListItem from '@/components/list/RankingListItem';
+import userIcon from '@/assets/img/profile_member.svg';
+import arrowRight from '@/assets/icon/ic_arrow_right.svg';
+import arrowLeft from '@/assets/icon/ic_arrow_left.svg';
+
+function useIsTablet() {
+  const [isTablet, setIsTablet] = useState(false);
+  useEffect(() => {
+    const checkWidth = () => setIsTablet(window.innerWidth >= 768);
+    checkWidth();
+    window.addEventListener('resize', checkWidth);
+    return () => window.removeEventListener('resize', checkWidth);
+  }, []);
+  return isTablet;
+}
 
 export default function ChallengeDetailPage() {
+  const isTablet = useIsTablet();
+
   const dummyChallenge = {
-    title: "Next.js - App Router : Routing Fundamentals",
-    type: "nextjs",
-    category: "officialdoc",
-    deadline: "2025-06-01",
-    participants: "15/20",
+    title: 'Next.js - App Router : Routing Fundamentals',
+    type: '공식문서',
+    category: 'Next.js',
+    deadline: '2025-06-01',
+    participants: '15/20',
     description:
-      "Next.js App Router 공식 문서 중 Routing Fundamentals 내용입니다! 라우팅에 따른 폴더와 파일이 구성되는 법칙과 컨벤션 등에 대해 공부할 수 있을 것 같아요~! 다들 챌린지 많이 참여해 주세요 :)",
+      'Next.js App Router 공식 문서 중 Routing Fundamentals 내용입니다! 라우팅에 따른 폴더와 파일이 구성되는 법칙과 컨벤션 등에 대해 공부할 수 있을 것 같아요~! 다들 챌린지 많이 참여해 주세요 :)',
     createdBy: {
-      nickname: "dev_sungbin",
-      profileImage: userIcon,
-    },
+      nickname: '럽윈즈올',
+      profileImage: userIcon
+    }
   };
 
   const [rankingData, setRankingData] = useState([
-    {
-      rank: 1,
-      userName: "홍길동",
-      userRole: "전문가",
-      likes: 1234,
-      isLiked: false,
-      workId: 101,
-    },
-    {
-      rank: 2,
-      userName: "김철수",
-      userRole: "전문가",
-      likes: 456,
-      isLiked: true,
-      workId: 102,
-    },
-    {
-      rank: 3,
-      userName: "이영희",
-      userRole: "전문가",
-      likes: 789,
-      isLiked: false,
-      workId: 103,
-    },
-    {
-      rank: 4,
-      userName: "박민수",
-      userRole: "전문가",
-      likes: 321,
-      isLiked: false,
-      workId: 104,
-    },
-    {
-      rank: 5,
-      userName: "최지우",
-      userRole: "전문가",
-      likes: 654,
-      isLiked: true,
-      workId: 105,
-    },
-    {
-      rank: 6,
-      userName: "조성빈",
-      userRole: "전문가",
-      likes: 777,
-      isLiked: false,
-      workId: 106,
-    },
+    { rank: 1, userName: '개발life', userRole: '전문가', likes: 9999, isLiked: false, workId: 101 },
+    { rank: 2, userName: '라우터장인', userRole: '전문가', likes: 1800, isLiked: true, workId: 102 },
+    { rank: 3, userName: 'DevCat99', userRole: '전문가', likes: 700, isLiked: false, workId: 103 },
+    { rank: 4, userName: 'ts_master', userRole: '전문가', likes: 600, isLiked: false, workId: 104 },
+    { rank: 5, userName: '사피엔스', userRole: '전문가', likes: 500, isLiked: true, workId: 105 },
+    { rank: 6, userName: '조성빈', userRole: '전문가', likes: 312, isLiked: false, workId: 106 }
   ]);
 
   const itemsPerPage = 5;
@@ -82,86 +53,58 @@ export default function ChallengeDetailPage() {
   const handleToggleLike = (index) => {
     setRankingData((prev) =>
       prev.map((item, i) =>
-        i === index
-          ? {
-              ...item,
-              isLiked: !item.isLiked,
-              likes: item.isLiked ? item.likes - 1 : item.likes + 1,
-            }
-          : item,
-      ),
+        i === index ? { ...item, isLiked: !item.isLiked, likes: item.isLiked ? item.likes - 1 : item.likes + 1 } : item
+      )
     );
-  };
-
-  const goToPrevPage = () => {
-    if (currentPage > 1) setCurrentPage((prev) => prev - 1);
-  };
-
-  const goToNextPage = () => {
-    if (currentPage < totalPages) setCurrentPage((prev) => prev + 1);
   };
 
   const startIndex = (currentPage - 1) * itemsPerPage;
   const currentItems = rankingData.slice(startIndex, startIndex + itemsPerPage);
 
   return (
-    <main className="flex flex-col items-center px-4 pt-12">
-      <div className="w-full max-w-sm">
-        <ChallengeCard
-          title={dummyChallenge.title}
-          type={dummyChallenge.type}
-          category={dummyChallenge.category}
-          deadline={dummyChallenge.deadline}
-          participants={dummyChallenge.participants}
-          variant="simple"
-        />
-      </div>
+    <main className="flex flex-col items-center px-4 bg-white">
+      <section className="flex flex-col gap-4 md:flex-row md:items-start md:justify-center md:gap-6 w-full max-w-6xl">
+        <div className="flex flex-col gap-2 w-full md:w-2/3">
+          <ChallengeCard {...dummyChallenge} variant="simple" />
 
-      {/* 설명 */}
-      <section className="mt-6 w-full max-w-sm text-gray-800">
-        <p className="text-base leading-relaxed whitespace-pre-line">
-          {dummyChallenge.description}
-        </p>
+          <section className="text-gray-800 px-1 sm:px-2 md:px-4">
+            <p className="text-sm md:text-base leading-[1.3] whitespace-pre-line">{dummyChallenge.description}</p>
+          </section>
+
+          <section className="flex items-center gap-2 p-3">
+            <Image
+              src={dummyChallenge.createdBy.profileImage}
+              alt="작성자 프로필"
+              width={32}
+              height={32}
+              className="rounded-full"
+            />
+            <span className="text-sm font-medium text-gray-700">{dummyChallenge.createdBy.nickname}</span>
+          </section>
+        </div>
+
+        <div className="w-full md:w-1/3">
+          <ChallengeContainerd height="h-auto" type={isTablet ? '' : 'slim'} />
+        </div>
       </section>
 
-      {/* 작성자 정보 */}
-      <section className="mt-6 flex w-full max-w-sm items-center gap-2">
-        <Image
-          src={dummyChallenge.createdBy.profileImage}
-          alt="작성자 프로필"
-          width={32}
-          height={32}
-          className="rounded-full"
-        />
-        <span className="text-sm font-medium text-gray-700">
-          {dummyChallenge.createdBy.nickname}
-        </span>
-      </section>
-
-      {/* 도전하기 버튼 */}
-      <section className="mt-8 w-full max-w-sm">
-        <ChallengeContainerd height="h-auto" type="slim" />
-      </section>
-
-      {/* 참여현황 리스트 */}
-      <section className="mt-10 w-full max-w-sm rounded-xl border-2 border-gray-800 bg-white">
+      <section className="mt-10 w-full max-w-6xl rounded-xl border-2 border-gray-800 bg-white">
         <div className="flex items-center justify-between px-4 py-3">
-          <h3 className="text-base font-semibold text-gray-800">참여현황</h3>
-          <div className="flex items-center gap-2">
-            <span className="rounded-full bg-gray-50 px-3 py-0.5 text-sm text-gray-800">
-              {currentPage} / {totalPages}
-            </span>
-            <button onClick={goToPrevPage} disabled={currentPage === 1}>
+          <h3 className="text-base md:text-lg font-semibold text-gray-800">참여현황</h3>
+          <div className="flex items-center gap-2 text-sm md:text-base">
+            <span className="text-[var(--color-brand-yellow)] font-semibold">{currentPage}</span>
+            <span className="text-gray-800">/ {totalPages}</span>
+            <button onClick={() => setCurrentPage((p) => Math.max(p - 1, 1))} disabled={currentPage === 1}>
               <Image
                 src={arrowLeft}
                 alt="이전"
                 width={20}
                 height={20}
-                className={`${currentPage === 1 ? "opacity-30" : ""}`}
+                className={currentPage === 1 ? 'opacity-30' : ''}
               />
             </button>
             <button
-              onClick={goToNextPage}
+              onClick={() => setCurrentPage((p) => Math.min(p + 1, totalPages))}
               disabled={currentPage === totalPages}
             >
               <Image
@@ -169,7 +112,7 @@ export default function ChallengeDetailPage() {
                 alt="다음"
                 width={20}
                 height={20}
-                className={`${currentPage === totalPages ? "opacity-30" : ""}`}
+                className={currentPage === totalPages ? 'opacity-30' : ''}
               />
             </button>
           </div>
@@ -177,11 +120,7 @@ export default function ChallengeDetailPage() {
 
         <div className="px-4">
           {currentItems.map((item, index) => (
-            <RankingListItem
-              key={item.rank}
-              item={item}
-              toggleLike={() => handleToggleLike(startIndex + index)}
-            />
+            <RankingListItem key={item.rank} item={item} toggleLike={() => handleToggleLike(startIndex + index)} />
           ))}
         </div>
       </section>

--- a/src/app/(user)/challenges/_components/challengeCard/ChallengeContainer.jsx
+++ b/src/app/(user)/challenges/_components/challengeCard/ChallengeContainer.jsx
@@ -1,17 +1,17 @@
-import React from "react";
-import Image from "next/image";
-import clock from "@/assets/icon/ic_clock.svg";
-import callengers from "@/assets/icon/ic_person.svg";
+import React from 'react';
+import Image from 'next/image';
+import clock from '@/assets/icon/ic_clock.svg';
+import callengers from '@/assets/icon/ic_person.svg';
 
 //type은 "slim", "" 사용 가능
 export default function ChallengeContainerd({ height, type }) {
   return (
     <>
       <div
-        className={`${height} flex items-center rounded-2xl bg-[var(--color-gray-50)] font-[var(--font-pretendard)]`}
+        className={`${height} flex items-center rounded-2xl bg-white border border-gray-100 font-[var(--font-pretendard)]`}
       >
         <div
-          className={`flex w-full flex-col items-center gap-[16px] px-[16px] ${type === "slim" ? "py-[12px]" : "py-[24px]"}`}
+          className={`flex w-full flex-col items-center gap-[16px] px-[16px] ${type === 'slim' ? 'py-[12px]' : 'py-[24px]'}`}
         >
           <div className="flex h-[24px] flex-row items-center justify-center gap-[4px] text-[13px]">
             {/* 백엔드와 데이터 연결 필요 */}
@@ -20,9 +20,7 @@ export default function ChallengeContainerd({ height, type }) {
             <Image src={callengers} alt="사람들 이모지" />
             15/15
           </div>
-          <div
-            className={`flex ${type === "slim" ? "flex-row" : "h-[88px] flex-col"} w-full gap-[8px]`}
-          >
+          <div className={`flex ${type === 'slim' ? 'flex-row' : 'h-[88px] flex-col'} w-full gap-[8px]`}>
             <button className="flex h-[40px] flex-1 items-center justify-center rounded-xl border-2 bg-[var(--color-brand-yellow)] text-[14px] font-bold">
               원문 보기
             </button>

--- a/src/components/card/Card.jsx
+++ b/src/components/card/Card.jsx
@@ -1,13 +1,13 @@
-"use client";
+'use client';
 
-import Image from "next/image";
-import dropdownIcon from "@/assets/icon/ic_menu.svg";
-import clockIcon from "@/assets/icon/ic_clock.svg";
-import usersIcon from "@/assets/icon/ic_person.svg";
-import { typeChipMap, categoryChipMap } from "../chip/chipMaps";
+import Image from 'next/image';
+import dropdownIcon from '@/assets/icon/ic_menu.svg';
+import clockIcon from '@/assets/icon/ic_clock.svg';
+import usersIcon from '@/assets/icon/ic_person.svg';
+import { typeChipMap, categoryChipMap } from '../chip/chipMaps';
 
-import ChipCardStatus from "@/components/chip/chipComplete/ChipCardStatus"; // 좌상단 chip
-import { useEffect, useState } from "react";
+import ChipCardStatus from '@/components/chip/chipComplete/ChipCardStatus'; // 좌상단 chip
+import { useEffect, useState } from 'react';
 
 export default function ChallengeCard({
   title,
@@ -16,39 +16,46 @@ export default function ChallengeCard({
   deadline,
   participants,
   maxParticipant,
+  variant = 'default'
 }) {
-  const [status, setStatus] = useState("");
+  const [status, setStatus] = useState('');
 
   //챌린지 상태(status) 계산
   useEffect(() => {
     const now = new Date();
     const deadlineDate = new Date(deadline);
     if (participants >= maxParticipant) {
-      setStatus("closed");
+      setStatus('closed');
     } else if (now > deadlineDate) {
-      setStatus("expired");
+      setStatus('expired');
     } else {
-      setStatus("");
+      setStatus('');
     }
   }, [deadline, maxParticipant, participants]);
 
   //날짜 prettier
   const formatDateToPretty = (dateString) => {
     const date = new Date(dateString);
-    return new Intl.DateTimeFormat("ko-KR", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
+    return new Intl.DateTimeFormat('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
     }).format(date);
   };
 
   return (
-    <div className="flex h-[227px] w-full max-w-[996px] flex-col justify-between rounded-[12px] border-2 border-[var(--color-gray-800)] bg-white p-4 shadow-md sm:h-[262px] sm:max-w-[343px] md:h-[225px] md:max-w-[696px]">
+    <div
+      className={`flex w-full flex-col
+  ${variant === 'simple' ? 'h-auto justify-start' : 'h-[227px] justify-between sm:h-[262px] md:h-[225px]'}
+  ${variant === 'simple' ? '' : 'rounded-[12px] border-2 border-[var(--color-gray-800)]'}
+  bg-white p-4 
+  max-w-[996px] sm:max-w-[343px] md:max-w-[696px]`}
+    >
       <div className="flex items-start justify-between">
         {status ? (
           <ChipCardStatus status={status} />
         ) : (
-          <div className="invisible w-fit" />
+          <div className="text-xl font-semibold text-gray-800">{title}</div>
         )}
 
         <button>
@@ -56,31 +63,33 @@ export default function ChallengeCard({
         </button>
       </div>
 
-      {status && (
-        <div className="mt-2 text-xl font-semibold text-gray-800">{title}</div>
-      )}
+      {status && <div className="mt-2 text-xl font-semibold text-gray-800">{title}</div>}
 
       <div className="mt-2 flex flex-wrap gap-2">
         {categoryChipMap[category] ?? null}
         {typeChipMap[type] ?? null}
       </div>
 
-      <hr className="my-4 border-gray-200" />
+      {variant !== 'simple' && (
+        <>
+          <hr className="my-4 border-gray-200" />
 
-      <div className="flex justify-between text-sm text-gray-500">
-        <div className="flex gap-4">
-          <div className="flex items-center gap-1">
-            <Image src={clockIcon} alt="시계" width={16} height={16} />
-            <span>{formatDateToPretty(deadline)} 마감</span>
+          <div className="flex justify-between text-sm text-gray-500">
+            <div className="flex gap-4">
+              <div className="flex items-center gap-1">
+                <Image src={clockIcon} alt="시계" width={16} height={16} />
+                <span>{formatDateToPretty(deadline)} 마감</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <Image src={usersIcon} alt="사람" width={16} height={16} />
+                <span>
+                  {participants}/{maxParticipant}
+                </span>
+              </div>
+            </div>
           </div>
-          <div className="flex items-center gap-1">
-            <Image src={usersIcon} alt="사람" width={16} height={16} />
-            <span>
-              {participants}/{maxParticipant}
-            </span>
-          </div>
-        </div>
-      </div>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 📌 챌린지 상세 페이지 개선 PR

### ✅ 주요 변경 사항

- **`ChallengeCard` 컴포넌트 개선**
  - `variant = "default"` 기본값 추가
  - `title` 조건부 렌더링 제거 (`variant`로 분기)
  - 스타일을 모두 Tailwind spacing 유닛(`px-1`, `py-3`, `p-4`)으로 변환
  - 불필요한 조건문 및 반복 구조 정리

- **`ChallengeContainerd` 컴포넌트 UI 변경**
  - 배경색을 `white`로 변경
  - border 색상 `gray-100` 추가

- **챌린지 상세 페이지 구조 리팩토링**
  - 카드 및 설명 영역을 반응형 2열 레이아웃으로 구성 (`md:flex-row`)
  - 카드 좌우 여백과 설명 섹션 여백 일치 (`md:px-4`)
  - 참여현황 리스트 포함 전체 UI 정돈
  - `dummyChallenge` 구조 간결화 (`...dummyChallenge` 사용)

- **반응형 대응**
  - 모바일: 카드 → 설명 → 작성자 정보 → 컨테이너(`slim`) 순서
  - 태블릿 이상: 카드/설명 + 컨테이너 병렬 배치, 참여현황은 하단 유지
  - `type` prop은 화면 사이즈에 따라 자동 분기 (`useIsTablet()` 훅 사용)
  - 브레이크포인트는 추후 논의하여 조정 예정

- **UI 재적용**
  - 카드 컴포넌트 구조 변경으로 인해 빠졌던 UI 요소(title, chip 등) 복구 및 적용

---

### 🔧 TODO

- 데스크탑/태블릿 정확한 브레이크포인트 확정 필요
- 반응형 추가 개선 필요 
- GNB 하단에 line 필요 
- 페이지 하단에 회색 영역 수정 필요 
