### PR TITLE
Feat/admin/manage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6439,6 +6439,7 @@
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.17.0.tgz",
       "integrity": "sha512-L/8HTylaBmIWwQzIjMq+0vyaRXuoAevzWoD35wKpNTxxtYXWZp+xtgkfD7Y4WItuX0YvdxMPU79+7VhhmbmuTQ==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/src/app/(auth)/signIn/page.jsx
+++ b/src/app/(auth)/signIn/page.jsx
@@ -1,38 +1,38 @@
-"use client";
+'use client';
 
-import Container from "@/components/container/PageContainer";
-import EmailInput from "@/components/input/EmailInput";
-import PasswordInput from "@/components/input/PasswordInput";
-import SubmitButton from "@/components/btn/auth/SubmitButton";
-import Logo from "@/layout/_components/Logo";
-import Link from "next/link";
-import { useAuth } from "@/providers/AuthProvider";
-import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
-import GoogleLoginButton from "@/components/btn/auth/GoogleLoginButton";
+import Container from '@/components/container/PageContainer';
+import EmailInput from '@/components/input/EmailInput';
+import PasswordInput from '@/components/input/PasswordInput';
+import SubmitButton from '@/components/btn/auth/SubmitButton';
+import Logo from '@/layout/_components/Logo';
+import Link from 'next/link';
+import { useAuth } from '@/providers/AuthProvider';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import GoogleLoginButton from '@/components/btn/auth/GoogleLoginButton';
 
 export default function SignInPage() {
-  const { login, user, isLoading } = useAuth()
+  const { login, user, isLoading } = useAuth();
   const router = useRouter();
 
-  const [email, setEmail] = useState("")
-  const [password, setPassword] = useState('')
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
 
   const handleLogin = async (e) => {
     e.preventDefault();
     try {
-      await login(email, password) // 로그인
+      await login(email, password); // 로그인
     } catch (error) {
-      console.error("로그인 실패", error);
-      alert("로그인에 실패했습니다. 이메일과 비밀번호를 확인해주세요.")
+      console.error('로그인 실패', error);
+      alert('로그인에 실패했습니다. 이메일과 비밀번호를 확인해주세요.');
     }
-  }
+  };
 
   useEffect(() => {
     console.log('User status changed:', user);
     if (user) {
       console.log('Redirecting to /');
-      router.push('/');
+      router.push('/challenges');
     }
   }, [user, router]);
 
@@ -43,7 +43,7 @@ export default function SignInPage() {
         <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
         <p className="ml-4">인증 정보를 확인 중입니다...</p>
       </div>
-    )
+    );
   }
 
   return (
@@ -51,8 +51,18 @@ export default function SignInPage() {
       <div className="mt-15 mb-30 flex flex-col items-center md:mt-30">
         <Logo className="mb-10 h-[54px] w-60 md:h-18 md:w-80" />
         <form className="mb-[18px] space-y-6" onSubmit={handleLogin}>
-          <EmailInput value={email} onChange={(e) => { setEmail(e.target.value) }} />
-          <PasswordInput value={password} onChange={(e) => { setPassword(e.target.value) }} />
+          <EmailInput
+            value={email}
+            onChange={(e) => {
+              setEmail(e.target.value);
+            }}
+          />
+          <PasswordInput
+            value={password}
+            onChange={(e) => {
+              setPassword(e.target.value);
+            }}
+          />
           <SubmitButton type="로그인" />
         </form>
         <GoogleLoginButton />
@@ -63,6 +73,6 @@ export default function SignInPage() {
           </Link>
         </div>
       </div>
-    </Container >
+    </Container>
   );
 }

--- a/src/app/(user)/challenges/_components/myChallenges/appliedChallenges/AppliedChallenges.jsx
+++ b/src/app/(user)/challenges/_components/myChallenges/appliedChallenges/AppliedChallenges.jsx
@@ -1,33 +1,28 @@
-import React from 'react'
-import ListHead from './ListHead'
-import Pagination from '@/components/pagination/Pagination'
-import MapResultData from './MapResultData'
+import React from 'react';
+import ListHead from './ListHead';
+import Pagination from '@/components/pagination/Pagination';
+import MapResultData from './MapResultData';
 
 export default function AppliedChallenges({
-    columnSetting,
-    result,
-    onClick,
-    totalCount,
-    page,
-    pageSize,
-    onPageChange
+  columnSetting,
+  result,
+  onClick,
+  totalCount,
+  page,
+  pageSize,
+  onPageChange
 }) {
   return (
-    <div>
-        <ListHead columnSetting={columnSetting} />
-            <MapResultData 
-                columnSetting={columnSetting} // 매칭 데이터, 너비, 스타일링 셋팅
-                resultData={result} // api response
-                onClick={onClick} // 상세페이지로 이동
-            />
-            <div className="mt-5">
-            <Pagination
-                totalCount={totalCount}
-                currentPage={page}
-                pageSize={pageSize}
-                onPageChange={onPageChange}
-            />
+    <div className="overflow-scroll">
+      <ListHead columnSetting={columnSetting} />
+      <MapResultData
+        columnSetting={columnSetting} // 매칭 데이터, 너비, 스타일링 셋팅
+        resultData={result} // api response
+        onClick={onClick} // 상세페이지로 이동
+      />
+      <div className="mt-5">
+        <Pagination totalCount={totalCount} currentPage={page} pageSize={pageSize} onPageChange={onPageChange} />
       </div>
     </div>
-  )
+  );
 }

--- a/src/app/(user)/challenges/_components/myChallenges/appliedChallenges/MapResultData.jsx
+++ b/src/app/(user)/challenges/_components/myChallenges/appliedChallenges/MapResultData.jsx
@@ -1,20 +1,14 @@
-"use client"
+'use client';
 
-import React, { useState } from 'react'
-import ListRow from './ListRow'
+import React, { useState } from 'react';
+import ListRow from './ListRow';
 
-export default function MapResultData({ resultData, columnSetting, onClick}) {
-
+export default function MapResultData({ resultData, columnSetting, onClick }) {
   return (
-    <div >
-        {resultData.map((dataList, key) => (
-          <ListRow 
-            key={key} 
-            data={dataList} 
-            columnSetting={columnSetting}
-            onClick={() => onClick(dataList.id)}
-          />
-          ))}
+    <div>
+      {resultData?.map((dataList, key) => (
+        <ListRow key={key} data={dataList} columnSetting={columnSetting} onClick={() => onClick(dataList.id)} />
+      ))}
     </div>
-  )
+  );
 }

--- a/src/app/(user)/challenges/layout.jsx
+++ b/src/app/(user)/challenges/layout.jsx
@@ -1,30 +1,35 @@
-"use client";
+'use client';
 
-import Gnb from "@/layout/Gnb";
-import { usePathname } from "next/navigation";
-import React from "react";
+import Gnb from '@/layout/Gnb';
+import { useAuth } from '@/providers/AuthProvider';
+import { usePathname } from 'next/navigation';
+import React from 'react';
 
 // GNB를 제외할 경로들을 배열로 관리
 const excludeGnbPaths = [
-  "/challenges/[challengeId]/work/create",
-  "/challenges/[challengeId]/work/[workId]/edit",
+  '/challenges/[challengeId]/work/create',
+  '/challenges/[challengeId]/work/[workId]/edit'
   // 추후 GNB를 제외할 경로들을 여기에 추가
 ];
 
 export default function ChallengesLayout({ children }) {
   const pathname = usePathname();
+  const { user } = useAuth();
+
+  // TODO: 추후 변경
+  const userRole = user?.nickname === '관리자' ? 'admin' : 'member';
 
   // 현재 경로가 excludeGnbPaths 배열에 있는 패턴과 일치하는지 확인
   const shouldExcludeGnb = excludeGnbPaths.some((path) => {
     // 동적 라우트 파라미터([challengeId] 등)를 정규식 패턴으로 변환
-    const pathPattern = path.replace(/\[.*?\]/g, "[^/]+");
+    const pathPattern = path.replace(/\[.*?\]/g, '[^/]+');
     const regex = new RegExp(`^${pathPattern}$`);
     return regex.test(pathname);
   });
 
   return (
     <div>
-      {!shouldExcludeGnb && <Gnb userRole="member" />}
+      {!shouldExcludeGnb && <Gnb userRole={userRole} />}
       {children}
     </div>
   );

--- a/src/app/(user)/challenges/mychallenges/page.jsx
+++ b/src/app/(user)/challenges/mychallenges/page.jsx
@@ -1,19 +1,18 @@
-"use client";
+'use client';
 
-import React, { useEffect, useState } from "react";
-import Container from "@/components/container/PageContainer";
-import SearchInput from "@/components/input/SearchInput";
-import Profile from "@/components/dropDown/Profile";
+import React, { useEffect, useState } from 'react';
+import Container from '@/components/container/PageContainer';
+import SearchInput from '@/components/input/SearchInput';
 import { appliedChallenges } from '@/lib/api/myChallenges';
 import ApplyChallenge from '../_components/ApplyChallenge';
 import { useRouter } from 'next/navigation';
 import MyChallengesTab from '../_components/myChallenges/MyChallengesTab';
 import FilterModal from '@/components/modal/FilterModal';
 import Sort from '@/components/sort/Sort';
-import { useAuth } from "@/providers/AuthProvider";
-import { getUserAction } from "@/lib/actions/auth";
-import { columnSetting } from "@/constant/constant";
-import AppliedChallenges from "../_components/myChallenges/appliedChallenges/AppliedChallenges";
+import { useAuth } from '@/providers/AuthProvider';
+import { getUserAction } from '@/lib/actions/auth';
+import { columnSetting } from '@/constant/constant';
+import AppliedChallenges from '../_components/myChallenges/appliedChallenges/AppliedChallenges';
 
 export default function page() {
   const router = useRouter();
@@ -24,8 +23,8 @@ export default function page() {
   const endIndex = startIndex + pageSize;
   const [result, setResult] = useState([]);
   const { user, isLoading } = useAuth();
-  
-  if(isLoading) return (<div>로딩 중..</div>);
+
+  if (isLoading) return <div>로딩 중..</div>;
 
   async function appliedChallengesData() {
     try {
@@ -33,34 +32,37 @@ export default function page() {
       console.log(data);
       setResult(data);
     } catch (error) {
-      console.error("목록 불러오기 실패");
+      console.error('목록 불러오기 실패');
     }
   }
   if (isLoading) return <div>로딩 중...</div>;
   if (!user) return <div>로그인이 필요합니다.</div>;
-  
+
   //신청한 챌린지 목록 불러오기
 
-  useEffect(()=>{
-   if (user) appliedChallengesData();
-  },[])
+  useEffect(() => {
+    if (user) appliedChallengesData();
+  }, []);
 
   return (
     <Container>
       <div className="flex justify-between h-10 mt-4">
-        <h2 className="flex-1 text-xl font-semibold">
-          나의 챌린지 
-        </h2>
+        <h2 className="flex-1 text-xl font-semibold">나의 챌린지</h2>
         <ApplyChallenge />
       </div>
       <MyChallengesTab />
       <div className="flex justify-between mb-4 gap-2">
-        <div className="flex-7 sm:flex-8"> <SearchInput /></div>
-        <div className="flex-3 sm:flex-2"><Sort /></div>
+        <div className="flex-7 sm:flex-8">
+          {' '}
+          <SearchInput />
+        </div>
+        <div className="flex-3 sm:flex-2">
+          <Sort />
+        </div>
       </div>
-      <AppliedChallenges 
-        columnSetting={columnSetting} 
-        result={result} 
+      <AppliedChallenges
+        columnSetting={columnSetting}
+        result={result}
         onClick={(id) => router.push(`/challenges/${id}`)}
         totalCount={totalCount}
         page={page}
@@ -70,4 +72,3 @@ export default function page() {
     </Container>
   );
 }
-

--- a/src/app/admin/layout.jsx
+++ b/src/app/admin/layout.jsx
@@ -1,11 +1,11 @@
-import Gnb from "@/layout/Gnb";
-import React from "react";
+import Container from '@/components/container/PageContainer';
+import Gnb from '@/layout/Gnb';
 
 export default function AdminLayout({ children }) {
   return (
-    <div>
+    <>
       <Gnb userRole="admin" />
-      {children}
-    </div>
+      <Container>{children}</Container>
+    </>
   );
 }

--- a/src/app/admin/management/page.jsx
+++ b/src/app/admin/management/page.jsx
@@ -1,7 +1,53 @@
-import Container from "@/components/container/PageContainer";
+'use client';
 
-const page = () => {
-  return <Container>관리자 매니징 페이지</Container>;
-};
+import AppliedChallenges from '@/app/(user)/challenges/_components/myChallenges/appliedChallenges/AppliedChallenges';
+import DropdownListLeftSmall from '@/components/dropDown/list/DropdownListLeftSmall';
+import SearchInput from '@/components/input/SearchInput';
+import Sort from '@/components/sort/Sort';
+import { columnSetting, ITEM_COUNT } from '@/constant/constant';
+import { getChallenges } from '@/lib/api/searchChallenges';
+import { useEffect, useState } from 'react';
 
-export default page;
+function AdminManagementPage() {
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [applications, setApplications] = useState();
+  const [totalCount, setTotalCount] = useState(null);
+  const [page, setPage] = useState(1);
+
+  const pageSize = ITEM_COUNT.APPLICATION;
+
+  const handleClickSort = () => setIsDropdownOpen((prev) => !prev);
+
+  const getApplications = async () => {
+    const challenges = await getChallenges({ page, pageSize });
+    setApplications(challenges?.data);
+    setTotalCount(challenges?.totalCount);
+  };
+
+  useEffect(() => {
+    getApplications();
+  }, [page]);
+
+  return (
+    <>
+      <h1 className="text-xl font-semibold mt-[26px] md:mt-[34px] mb-[13px] md:mb-6">챌린지 신청 관리</h1>
+      <div className="mb-4 md:mb-6 grid grid-cols-[2fr_1fr] gap-3 md:grid-cols-[4fr_1fr] lg:grid-cols-[6fr_1fr]">
+        <SearchInput />
+        <div className="relative">
+          <Sort isAdminStatus={true} onClick={handleClickSort} />
+          <div className="absolute right-0 mt-2">{isDropdownOpen && <DropdownListLeftSmall />}</div>
+        </div>
+      </div>
+      <AppliedChallenges
+        columnSetting={columnSetting}
+        result={applications}
+        totalCount={totalCount}
+        page={page}
+        pageSize={pageSize}
+        onPageChange={(newPage) => setPage(newPage)}
+      />
+    </>
+  );
+}
+
+export default AdminManagementPage;

--- a/src/app/admin/management/page.jsx
+++ b/src/app/admin/management/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import AppliedChallenges from '@/app/(user)/challenges/_components/myChallenges/appliedChallenges/AppliedChallenges';
-import DropdownListLeftSmall from '@/components/dropDown/list/DropdownListLeftSmall';
+import DropdownListLeftSmall from '@/components/dropdown/list/DropdownListLeftSmall';
 import SearchInput from '@/components/input/SearchInput';
 import Sort from '@/components/sort/Sort';
 import { columnSetting, ITEM_COUNT } from '@/constant/constant';

--- a/src/app/example/page.jsx
+++ b/src/app/example/page.jsx
@@ -1,40 +1,40 @@
-"use client";
+'use client';
 
-import { useState } from "react";
-import BtnText, { BtnRoundedWithIcon } from "@/components/btn/text/BtnText";
-import Container from "@/components/container/PageContainer";
-import DeclineModal from "@/components/modal/DeclineModal";
-import DeleteModal from "@/components/modal/DeleteModal";
-import FilterModal from "@/components/modal/FilterModal";
-import NotificationModal from "@/components/modal/NotificationModal";
-import SignupModal from "@/components/modal/SignupModal";
-import TemporaryStorage from "@/components/modal/DraftModal";
-import Sort from "@/components/sort/Sort";
-import RankingListItem from "@/components/list/RankingListItem";
-import Reply from "@/components/reply/Reply";
-import IconPasswordVisible from "@/components/btn/icon/BtnIcon";
-import BtnCheckbox from "@/components/btn/form/BtnCheckbox";
-import BtnRadio from "@/components/btn/form/BtnRadio";
-import Pagination from "@/components/pagination/Pagination";
-import ChallengeContainerd from "../(user)/challenges/_components/challengeCard/ChallengeContainer";
-import SearchInput from "@/components/input/SearchInput";
-import Profile from "@/components/dropDown/Profile";
-import ApplyChallenge from "../(user)/challenges/_components/ApplyChallenge";
-import Input from "../(user)/challenges/create/component/Input";
+import { useState } from 'react';
+import BtnText, { BtnRoundedWithIcon } from '@/components/btn/text/BtnText';
+import Container from '@/components/container/PageContainer';
+import DeclineModal from '@/components/modal/DeclineModal';
+import DeleteModal from '@/components/modal/DeleteModal';
+import FilterModal from '@/components/modal/FilterModal';
+import NotificationModal from '@/components/modal/NotificationModal';
+import SignupModal from '@/components/modal/SignupModal';
+import TemporaryStorage from '@/components/modal/DraftModal';
+import Sort from '@/components/sort/Sort';
+import RankingListItem from '@/components/list/RankingListItem';
+import Reply from '@/components/reply/Reply';
+import IconPasswordVisible from '@/components/btn/icon/BtnIcon';
+import BtnCheckbox from '@/components/btn/form/BtnCheckbox';
+import BtnRadio from '@/components/btn/form/BtnRadio';
+import Pagination from '@/components/pagination/Pagination';
+import ChallengeContainerd from '../(user)/challenges/_components/challengeCard/ChallengeContainer';
+import SearchInput from '@/components/input/SearchInput';
+import Profile from '@/components/dropdown/Profile';
+import ApplyChallenge from '../(user)/challenges/_components/ApplyChallenge';
+import Input from '../(user)/challenges/create/component/Input';
 
-const themesTitle = "mb-1 font-[600]";
+const themesTitle = 'mb-1 font-[600]';
 const MODAL_COMPONENTS = {
   signup: SignupModal,
   decline: DeclineModal,
   delete: DeleteModal,
   notification: NotificationModal,
   filter: FilterModal,
-  temp: TemporaryStorage,
+  temp: TemporaryStorage
 };
 
 const page = () => {
   const [openModal, setOpenModal] = useState(null);
-  const [selected, setSelected] = useState("option1");
+  const [selected, setSelected] = useState('option1');
   const [page, setPage] = useState(1);
 
   const handleOpen = (modalName) => setOpenModal(modalName);
@@ -47,9 +47,8 @@ const page = () => {
         <div className="m-10 flex flex-col gap-4 bg-white p-4">
           <h2 className="text-3xl font-bold">BtnText</h2>
           <span>
-            거의 모든 버튼이 BtnText.jsx에 포함되어 있으며 BtnText /
-            BtnRoundedWithIcon 로 나뉘어져 있음, rounded-full 버튼 속성으로 인해
-            분리함
+            거의 모든 버튼이 BtnText.jsx에 포함되어 있으며 BtnText / BtnRoundedWithIcon 로 나뉘어져 있음, rounded-full
+            버튼 속성으로 인해 분리함
           </span>
           <div>
             <div className={`${themesTitle}`}>theme = "tonal"</div>
@@ -86,15 +85,10 @@ const page = () => {
           <div>
             <div>
               <div className={`${themesTitle}`}>iconType = "goToMyWork"</div>
-              <BtnRoundedWithIcon iconType="goToMyWork">
-                내 작업물 보기
-              </BtnRoundedWithIcon>
+              <BtnRoundedWithIcon iconType="goToMyWork">내 작업물 보기</BtnRoundedWithIcon>
             </div>
             <div>
-              <div className={`${themesTitle}`}>
-                {" "}
-                iconType = "continueChallenge" (default 설정)
-              </div>
+              <div className={`${themesTitle}`}> iconType = "continueChallenge" (default 설정)</div>
               <BtnRoundedWithIcon>도전 계속하기</BtnRoundedWithIcon>
             </div>
           </div>
@@ -103,9 +97,7 @@ const page = () => {
           <h2 className="text-3xl font-bold">BtnIcon</h2>
           <div>
             <div>
-              <div className={`${themesTitle}`}>
-                비밀번호 보기/숨기기 토글 버튼
-              </div>
+              <div className={`${themesTitle}`}>비밀번호 보기/숨기기 토글 버튼</div>
               <IconPasswordVisible />
               <IconPasswordVisible on={true} />
             </div>
@@ -116,8 +108,7 @@ const page = () => {
           <div>
             <div>
               <div className={`${themesTitle}`}>
-                checked={true} - 체크된 상태 / checked={false} - 체크되지 않은
-                상태
+                checked={true} - 체크된 상태 / checked={false} - 체크되지 않은 상태
               </div>
               <BtnCheckbox isChecked={true}>테스트</BtnCheckbox>
             </div>
@@ -128,25 +119,16 @@ const page = () => {
           <div>
             <div>
               <div className={`${themesTitle}`}>
-                clicked={true} - 선택된 상태 / clicked={false} - 선택되지 않은
-                상태
+                clicked={true} - 선택된 상태 / clicked={false} - 선택되지 않은 상태
               </div>
               <div>
                 <h2 className="mb-4 text-lg font-semibold">옵션 선택</h2>
 
-                <BtnRadio
-                  value="option1"
-                  checked={selected === "option1"}
-                  onChange={setSelected}
-                >
+                <BtnRadio value="option1" checked={selected === 'option1'} onChange={setSelected}>
                   옵션 1
                 </BtnRadio>
 
-                <BtnRadio
-                  value="option2"
-                  checked={selected === "option2"}
-                  onChange={setSelected}
-                >
+                <BtnRadio value="option2" checked={selected === 'option2'} onChange={setSelected}>
                   옵션 2
                 </BtnRadio>
               </div>
@@ -192,22 +174,22 @@ const page = () => {
             <RankingListItem
               item={{
                 rank: 1,
-                userName: "홍길동",
-                userRole: "프로그래머",
+                userName: '홍길동',
+                userRole: '프로그래머',
                 likes: 10000,
                 isLiked: false,
-                workId: 1,
+                workId: 1
               }}
               toggleLike={() => {}}
             />
             <RankingListItem
               item={{
                 rank: 2,
-                userName: "김코딩",
-                userRole: "디자이너",
+                userName: '김코딩',
+                userRole: '디자이너',
                 likes: 8500,
                 isLiked: true,
-                workId: 2,
+                workId: 2
               }}
               toggleLike={() => {}}
             />
@@ -251,37 +233,37 @@ const page = () => {
           <div className="flex flex-wrap gap-2">
             <button
               className="rounded-lg bg-gray-100 px-4 py-2 font-semibold text-gray-800 hover:bg-gray-200"
-              onClick={() => handleOpen("signup")}
+              onClick={() => handleOpen('signup')}
             >
               회원가입
             </button>
             <button
               className="rounded-lg bg-gray-100 px-4 py-2 font-semibold text-gray-800 hover:bg-gray-200"
-              onClick={() => handleOpen("decline")}
+              onClick={() => handleOpen('decline')}
             >
               거절 사유
             </button>
             <button
               className="rounded-lg bg-gray-100 px-4 py-2 font-semibold text-gray-800 hover:bg-gray-200"
-              onClick={() => handleOpen("delete")}
+              onClick={() => handleOpen('delete')}
             >
               삭제
             </button>
             <button
               className="rounded-lg bg-gray-100 px-4 py-2 font-semibold text-gray-800 hover:bg-gray-200"
-              onClick={() => handleOpen("notification")}
+              onClick={() => handleOpen('notification')}
             >
               알림
             </button>
             <button
               className="rounded-lg bg-gray-100 px-4 py-2 font-semibold text-gray-800 hover:bg-gray-200"
-              onClick={() => handleOpen("filter")}
+              onClick={() => handleOpen('filter')}
             >
               필터
             </button>
             <button
               className="rounded-lg bg-gray-100 px-4 py-2 font-semibold text-gray-800 hover:bg-gray-200"
-              onClick={() => handleOpen("temp")}
+              onClick={() => handleOpen('temp')}
             >
               임시저장
             </button>
@@ -293,18 +275,14 @@ const page = () => {
       {/* Pagination 컴포넌트 설명 */}
       <div className="m-10 flex flex-col gap-8 bg-white p-4">
         <h2 className="text-3xl font-bold">Pagination</h2>
-        <Pagination
-          totalCount={183}
-          currentPage={page}
-          onPageChange={(newPage) => setPage(newPage)}
-        />
+        <Pagination totalCount={183} currentPage={page} onPageChange={(newPage) => setPage(newPage)} />
       </div>
 
       {/* Challenge container 컴포넌트*/}
       <div className="m-10 flex flex-col gap-8 bg-white p-4">
         <h2 className="text-3xl font-bold">challenge container</h2>
-        <ChallengeContainerd height={"h-[176px]"} type={""} />
-        <ChallengeContainerd height={"h-[104px]"} type={"slim"} />
+        <ChallengeContainerd height={'h-[176px]'} type={''} />
+        <ChallengeContainerd height={'h-[104px]'} type={'slim'} />
       </div>
 
       {/* SearchInput 컴포넌트
@@ -313,7 +291,7 @@ const page = () => {
       onChange={(e)=>setKeyword(e.target.value)}*/}
       <div className="m-10 flex flex-col gap-8 bg-white p-4">
         <h2 className="text-3xl font-bold">Search Input</h2>
-        <SearchInput text={"text-[14px]"} />
+        <SearchInput text={'text-[14px]'} />
       </div>
 
       {/* Dropdown Profile 컴포넌트
@@ -336,11 +314,7 @@ const page = () => {
           onChange={(e) => setOriginUrl(e.target.value)}*/}
       <div className="m-10 flex flex-col gap-8 bg-white p-4">
         <h2 className="text-3xl font-bold">정보입력(공통X)</h2>
-        <Input
-          title={"제목"}
-          placeholder={"제목을 입력해주세요"}
-          height={"h-[48px]"}
-        />
+        <Input title={'제목'} placeholder={'제목을 입력해주세요'} height={'h-[48px]'} />
       </div>
     </Container>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 /* ===========================
    🌈 Theme Variables
@@ -26,10 +26,9 @@
 
   /* ✅ Typography */
   --font-pretendard:
-    "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont,
-    system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo",
-    "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji",
-    "Segoe UI Symbol", sans-serif;
+    'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue',
+    'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', sans-serif;
 
   --font-quantico-regular: Quantico, sans-serif;
   --font-quantico-bold: Quantico, sans-serif;
@@ -45,7 +44,6 @@
 }
 
 @layer components {
-
   /* 버튼 컴포넌트 */
   .page-btn {
     @apply flex h-8 w-8 items-center justify-center rounded-lg text-sm font-medium text-gray-400 hover:bg-gray-200 md:h-10 md:w-10;
@@ -64,6 +62,11 @@
     font-family: var(--font-pretendard);
     background-color: var(--color-gray-50);
     color: var(--color-gray-900);
+  }
+
+  input:focus,
+  textarea:focus {
+    outline: 1px solid var(--color-gray-900);
   }
 
   button {

--- a/src/components/dropDown/Profile.jsx
+++ b/src/components/dropDown/Profile.jsx
@@ -10,25 +10,21 @@ import { useAuth } from '@/providers/AuthProvider';
 function Profile({ userRole }) {
   const router = useRouter();
   const isAdmin = userRole === 'admin';
-  const { user } = useAuth();
+  const { user, logout } = useAuth();
 
   const handleClickMychallenge = () => {
     router.push('/my/challenges');
   };
 
-  const handleClickLogout = () => {
-    router.push('/signIn');
-  };
-
   return (
-    <div className="flex flex-col items-start rounded-[8px] bg-[#FFFFFF] px-[16px] pt-[16px] pb-[8px] border border-gray-100">
-      <div className="flex w-fit flex-row justify-baseline gap-[8px]">
+    <div className="flex w-fit flex-col items-start rounded-[8px] bg-[#FFFFFF] px-[16px] pt-[16px] pb-[8px] border border-gray-100">
+      <div className="flex min-w-38 flex-row justify-baseline gap-[8px]">
         <Image src={isAdmin ? adminImage : userImage} alt="프로필 이미지" width={32} height={32} />
         <div className="flex flex-col gap-[2px]">
           {/* DB에서 불러온 유저 이름으로 변경 필수 */}
           <div className="text-[14px] font-medium text-[var(--color-gray-800)]">{user?.nickname}</div>
           {/* DB에서 불러온 유저 등급으로 변경 필수 */}
-          <div className="text-[12px] font-medium text-[var(--color-gray-500)]">{user?.role}</div>
+          <div className="text-[12px] font-medium text-[var(--color-gray-500)]">{isAdmin ? '어드민' : '전문가'}</div>
         </div>
       </div>
       <span className="flex w-full border-b-2 border-gray-100 my-2"></span>
@@ -40,7 +36,7 @@ function Profile({ userRole }) {
           나의 챌린지
         </button>
       )}
-      <button className="h-8 text-sm md:text-base font-medium text-[var(--color-gray-400)]" onClick={handleClickLogout}>
+      <button className="h-8 text-sm md:text-base font-medium text-[var(--color-gray-400)]" onClick={logout}>
         로그아웃
       </button>
     </div>

--- a/src/components/dropDown/Profile.jsx
+++ b/src/components/dropDown/Profile.jsx
@@ -1,49 +1,46 @@
-"use client";
+'use client';
 
-import React from "react";
-import Image from "next/image";
-import userImage from "@/assets/img/profile_member.svg";
-import { useRouter } from "next/navigation";
-// import adminImage from "@/assets/img/profile_admin.svg"
+import React from 'react';
+import Image from 'next/image';
+import userImage from '@/assets/img/profile_member.svg';
+import adminImage from '@/assets/img/profile_admin.svg';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/providers/AuthProvider';
 
-function Profile() {
+function Profile({ userRole }) {
   const router = useRouter();
+  const isAdmin = userRole === 'admin';
+  const { user } = useAuth();
 
   const handleClickMychallenge = () => {
-    // Url은 아직 미정입니다. 아래는 예시입니다
-    router.push("/my/challenges");
+    router.push('/my/challenges');
   };
 
   const handleClickLogout = () => {
-    // Url은 아직 미정입니다. 아래는 예시입니다
-    router.push("/login");
+    router.push('/signIn');
   };
+
   return (
-    <div className="flex w-[152px] flex-col items-start rounded-[8px] bg-[#FFFFFF] px-[16px] pt-[16px] pb-[8px]">
-      <div className="flex w-[120px] flex-row justify-baseline gap-[8px] border-b-2 border-[#F5F5F5] pb-[8px]">
-        {/* DB에서 불러온 유저 ROLE로 변경 필수 (어드민 이미지 import 완료) */}
-        <Image src={userImage} alt="일반 유저 프로필" />
+    <div className="flex flex-col items-start rounded-[8px] bg-[#FFFFFF] px-[16px] pt-[16px] pb-[8px] border border-gray-100">
+      <div className="flex w-fit flex-row justify-baseline gap-[8px]">
+        <Image src={isAdmin ? adminImage : userImage} alt="프로필 이미지" width={32} height={32} />
         <div className="flex flex-col gap-[2px]">
           {/* DB에서 불러온 유저 이름으로 변경 필수 */}
-          <div className="text-[14px] font-medium text-[var(--color-gray-800)]">
-            체다치즈
-          </div>
+          <div className="text-[14px] font-medium text-[var(--color-gray-800)]">{user?.nickname}</div>
           {/* DB에서 불러온 유저 등급으로 변경 필수 */}
-          <div className="text-[12px] font-medium text-[var(--color-gray-500)]">
-            전문가
-          </div>
+          <div className="text-[12px] font-medium text-[var(--color-gray-500)]">{user?.role}</div>
         </div>
       </div>
-      <button
-        className="pt-[15px] text-[16px] font-medium text-[var(--color-gray-800)]"
-        onClick={handleClickMychallenge}
-      >
-        나의 챌린지
-      </button>
-      <button
-        className="text-[14px] font-medium text-[var(--color-gray-400)]"
-        onClick={handleClickLogout}
-      >
+      <span className="flex w-full border-b-2 border-gray-100 my-2"></span>
+      {!isAdmin && (
+        <button
+          className="h-8 text-sm md:text-base font-medium text-[var(--color-gray-800)]"
+          onClick={handleClickMychallenge}
+        >
+          나의 챌린지
+        </button>
+      )}
+      <button className="h-8 text-sm md:text-base font-medium text-[var(--color-gray-400)]" onClick={handleClickLogout}>
         로그아웃
       </button>
     </div>

--- a/src/components/sort/Sort.jsx
+++ b/src/components/sort/Sort.jsx
@@ -1,43 +1,31 @@
-import Image from "next/image";
-import React from "react";
-import toggleDownIcon from "@/assets/icon/ic_toggle_down.svg";
-import filterIcon from "@/assets/icon/ic_filter.svg";
-import filterWhiteIcon from "@/assets/icon/ic_filter_white.svg";
+import Image from 'next/image';
+import React from 'react';
+import toggleDownIcon from '@/assets/icon/ic_toggle_down.svg';
+import filterIcon from '@/assets/icon/ic_filter.svg';
+import filterWhiteIcon from '@/assets/icon/ic_filter_white.svg';
 
 export default function Sort({ isAdminStatus, isFiltered, count, onClick }) {
-  const iconSrc = isAdminStatus
-    ? toggleDownIcon
-    : isFiltered
-      ? filterWhiteIcon
-      : filterIcon;
+  const iconSrc = isAdminStatus ? toggleDownIcon : isFiltered ? filterWhiteIcon : filterIcon;
 
   const containerClass = [
-    "flex w-full h-10 items-center justify-between gap-2 rounded-4xl border border-gray-300 px-3 py-2",
-    isAdminStatus && "pr-2",
-    isFiltered && "bg-gray-800",
+    'flex w-full h-10 items-center justify-between gap-2 rounded-4xl border border-gray-300 px-3 py-2',
+    isAdminStatus && 'pr-2',
+    isFiltered && 'bg-gray-800'
   ]
     .filter(Boolean)
-    .join(" ");
+    .join(' ');
 
-  const textClass = isFiltered ? "text-gray-50" : "text-gray-400";
+  const textClass = isFiltered ? 'text-gray-50' : 'text-gray-400';
 
-  const imageClass = isAdminStatus ? "h-6 w-6" : "";
+  const imageClass = isAdminStatus ? 'h-6 w-6' : '';
 
   return (
-    <div className={containerClass}>
+    <button className={containerClass} onClick={onClick}>
       <div className={`${textClass} flex w-full flex-row max-sm:text-sm`}>
-        <div>{isAdminStatus ? "승인 대기" : "필터"}</div>
-        <div>{count ? `(${count})` : ""}</div>
+        <div>{isAdminStatus ? '승인 대기' : '필터'}</div>
+        <div>{count ? `(${count})` : ''}</div>
       </div>
-      <button onClick={onClick}>
-        <Image
-          src={iconSrc}
-          width={16}
-          height={16}
-          alt="아이콘"
-          className={imageClass}
-        />
-      </button>
-    </div>
+      <Image src={iconSrc} width={16} height={16} alt="아이콘" className={imageClass} />
+    </button>
   );
 }

--- a/src/constant/constant.js
+++ b/src/constant/constant.js
@@ -1,7 +1,13 @@
-import AdminStatusChip from "../app/(user)/challenges/_components/myChallenges/appliedChallenges/AdminStatuschip.jsx"
+import AdminStatusChip from '../app/(user)/challenges/_components/myChallenges/appliedChallenges/AdminStatuschip.jsx';
 
 export const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 export const API_URL = process.env.API_URL;
+
+export const ITEM_COUNT = {
+  APPLICATION: 10,
+  CHALLENGE_LG: 5,
+  CHALLENGE_SM: 4
+};
 
 /* 
 신청한 챌린지
@@ -14,22 +20,23 @@ render : 해당 셀에 상태에 따라 다른 값을 노출해야 할 경우
 */
 
 export const columnSetting = [
-    { key: "id", label: "No.", flex: 0.6 , className: "pl-4" },
-    { key: "docType", label: "분야", flex: 1.2 },
-    { key: "category", label: "카테고리", flex: 1 },
-    { key: "title", label: "챌린지 제목", flex: 5, className: "text-gray-700 font-medium"},
-    { key: "maxParticipant", label: "인원", flex: 1 },
-    { key: "createdAt", label: "신청일", flex: 1 },
-    { key: "updatedAt", label: "마감기한", flex: 1 },
-    { 
-      key: "adminStatus", 
-      label: "상태", 
-      flex: 1.2, 
-      render: 
-        (data) => 
-          !!data.application?.adminStatus 
-          // adminStatus 필드를 사용할 경우 아래 컴포넌트 사용해 값마다 다른 스타일링을 보여줌
-          ? (<AdminStatusChip status={data.application?.adminStatus}/> ) 
-          : "null" 
-    }
-]
+  { key: 'id', label: 'No.', flex: 0.6, className: 'pl-4' },
+  { key: 'docType', label: '분야', flex: 1.2 },
+  { key: 'category', label: '카테고리', flex: 1 },
+  { key: 'title', label: '챌린지 제목', flex: 5, className: 'text-gray-700 font-medium' },
+  { key: 'maxParticipant', label: '인원', flex: 1 },
+  { key: 'createdAt', label: '신청일', flex: 1 },
+  { key: 'updatedAt', label: '마감기한', flex: 1 },
+  {
+    key: 'adminStatus',
+    label: '상태',
+    flex: 1.2,
+    render: (data) =>
+      !!data.application?.adminStatus ? (
+        // adminStatus 필드를 사용할 경우 아래 컴포넌트 사용해 값마다 다른 스타일링을 보여줌
+        <AdminStatusChip status={data.application?.adminStatus} />
+      ) : (
+        'null'
+      )
+  }
+];

--- a/src/hooks/useOutsideClick.js
+++ b/src/hooks/useOutsideClick.js
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+
+/**
+ * 외부 클릭 감지 커스텀 훅
+ * 사용법
+ * const profileRef = useRef(null)
+ * @param {*} ref - profileRef
+ * @param {*} handler - () => setIsProfileOpen(false)
+ */
+export function useOutsideClick(ref, handler) {
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) {
+        handler();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [ref, handler]);
+}

--- a/src/hooks/useViewport.js
+++ b/src/hooks/useViewport.js
@@ -1,13 +1,29 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect } from 'react';
 
+/**
+ * 사용예시
+  const [pageSize, setPageSize] = useState(BEST_ITEM_COUNT.pc);
+  const windowWidth = useViewport();
+
+  // 화면 너비 기준 보여줄 베스트 상품 수
+  useEffect(() => {
+    if (windowWidth >= BREAKPOINTS.lg) {
+      setPageSize(BEST_ITEM_COUNT.pc);
+    } else if (windowWidth >= BREAKPOINTS.md) {
+      setPageSize(BEST_ITEM_COUNT.tablet);
+    } else {
+      setPageSize(BEST_ITEM_COUNT.mobile);
+    }
+  }, [windowWidth]);
+ */
 export const useViewport = () => {
   const [width, setWidth] = useState(0);
 
   useEffect(() => {
     const handleWindowResize = () => setWidth(window.innerWidth);
     handleWindowResize();
-    window.addEventListener("resize", handleWindowResize);
-    return () => window.removeEventListener("resize", handleWindowResize);
+    window.addEventListener('resize', handleWindowResize);
+    return () => window.removeEventListener('resize', handleWindowResize);
   }, []);
 
   return width;

--- a/src/layout/Gnb.jsx
+++ b/src/layout/Gnb.jsx
@@ -1,79 +1,88 @@
-"use client";
+'use client';
 
-import Image from "next/image";
-import React from "react";
-import notiOff from "@/assets/icon/ic_noti_off.svg";
-import notiOn from "@/assets/icon/ic_noti_on.svg";
-import member from "@/assets/img/profile_member.svg";
-import admin from "@/assets/img/profile_admin.svg";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import Logo from "./_components/Logo";
+import Image from 'next/image';
+import React, { useState } from 'react';
+import notiOff from '@/assets/icon/ic_noti_off.svg';
+import notiOn from '@/assets/icon/ic_noti_on.svg';
+import member from '@/assets/img/profile_member.svg';
+import admin from '@/assets/img/profile_admin.svg';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import Logo from './_components/Logo';
+import Profile from '@/components/dropDown/Profile';
 
 export default function Gnb({ isNoti, userRole }) {
   const pathname = usePathname();
+  const [isProfileOpen, setIsProfileOpen] = useState(false);
+
+  const handleClickProfile = () => setIsProfileOpen((prev) => !prev);
 
   return (
-    <header className="flex h-14 items-center justify-between bg-[#FFFFFF] px-4 sm:px-6 md:h-15 lg:px-8">
-      <div className="flex items-center gap-4">
-        <Logo />
-        {userRole === "admin" && (
-          <>
-            <Link
-              href="/admin/management"
-              className={
-                pathname.includes("/management")
-                  ? "text-[13px] font-bold md:text-[15px]"
-                  : "text-[13px] font-bold text-gray-500 md:text-[15px]"
-              }
-            >
-              챌린지 관리
+    <>
+      <header className="flex h-14 items-center justify-between bg-[#FFFFFF] px-4 sm:px-6 md:h-15 lg:px-8">
+        <div className="flex items-center gap-4">
+          <Logo />
+          {userRole === 'admin' && (
+            <>
+              <Link
+                href="/admin/management"
+                className={
+                  pathname.includes('/management')
+                    ? 'text-[13px] font-bold md:text-[15px]'
+                    : 'text-[13px] font-bold text-gray-500 md:text-[15px]'
+                }
+              >
+                챌린지 관리
+              </Link>
+              <Link
+                href="/admin/challenges"
+                className={
+                  pathname.includes('/challenges')
+                    ? 'text-[13px] font-bold md:text-[15px]'
+                    : 'text-[13px] font-bold text-gray-500 md:text-[15px]'
+                }
+              >
+                챌린지 목록
+              </Link>
+            </>
+          )}
+        </div>
+        <div className="flex gap-4">
+          {userRole === 'member' && (
+            <>
+              <button aria-label="알림">
+                <Image
+                  src={isNoti ? notiOn : notiOff}
+                  alt={isNoti ? '알림 있음 아이콘' : '알림 없음 아이콘'}
+                  width={24}
+                  height={24}
+                />
+              </button>
+              <button aria-label="유저 프로필" onClick={handleClickProfile}>
+                <Image src={member} alt="유저 프로필" width={32} height={32} />
+              </button>
+            </>
+          )}
+          {userRole === 'admin' && (
+            <button aria-label="어드민 프로필" onClick={handleClickProfile}>
+              <Image src={admin} alt="어드민 프로필" width={32} height={32} />
+            </button>
+          )}
+          {userRole === 'guest' && (
+            <Link href="/signIn">
+              <button
+                className="h-8 w-20 rounded-[10px] border text-sm font-semibold md:h-10 md:w-[90x] md:text-base"
+                aria-label="로그인"
+              >
+                로그인
+              </button>
             </Link>
-            <Link
-              href="/admin/challenges"
-              className={
-                pathname.includes("/challenges")
-                  ? "text-[13px] font-bold md:text-[15px]"
-                  : "text-[13px] font-bold text-gray-500 md:text-[15px]"
-              }
-            >
-              챌린지 목록
-            </Link>
-          </>
-        )}
+          )}
+        </div>
+      </header>
+      <div className="absolute z-1 right-4 md:right-6 lg:right-8">
+        {isProfileOpen && <Profile userRole={userRole} />}
       </div>
-      <div className="flex gap-4">
-        {userRole === "member" && (
-          <>
-            <button aria-label="알림">
-              <Image
-                src={isNoti ? notiOn : notiOff}
-                alt={isNoti ? "알림 있음 아이콘" : "알림 없음 아이콘"}
-                width={24}
-                height={24}
-              />
-            </button>
-            <button aria-label="유저 프로필">
-              <Image src={member} alt="유저 프로필" width={32} height={32} />
-            </button>
-          </>
-        )}
-        {userRole === "admin" && (
-          <button aria-label="어드민 프로필">
-            <Image src={admin} alt="어드민 프로필" width={32} height={32} />
-          </button>
-        )}
-        {userRole === "guest" && (
-          <Link href="/signIn">
-            <button
-              className="h-8 w-20 rounded-[10px] border text-sm font-semibold md:h-10 md:w-[90x] md:text-base"
-              aria-label="로그인"
-            >
-              로그인
-            </button>
-          </Link>
-        )}
-      </div>
-    </header>
+    </>
   );
 }

--- a/src/layout/Gnb.jsx
+++ b/src/layout/Gnb.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import notiOff from '@/assets/icon/ic_noti_off.svg';
 import notiOn from '@/assets/icon/ic_noti_on.svg';
 import member from '@/assets/img/profile_member.svg';
@@ -10,79 +10,83 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import Logo from './_components/Logo';
 import Profile from '@/components/dropDown/Profile';
+import { useOutsideClick } from '@/hooks/useOutsideClick';
 
 export default function Gnb({ isNoti, userRole }) {
-  const pathname = usePathname();
   const [isProfileOpen, setIsProfileOpen] = useState(false);
+  const pathname = usePathname();
+  const profileRef = useRef(null);
+
+  useOutsideClick(profileRef, () => setIsProfileOpen(false));
 
   const handleClickProfile = () => setIsProfileOpen((prev) => !prev);
 
   return (
-    <>
-      <header className="flex h-14 items-center justify-between bg-[#FFFFFF] px-4 sm:px-6 md:h-15 lg:px-8">
-        <div className="flex items-center gap-4">
-          <Logo />
-          {userRole === 'admin' && (
-            <>
-              <Link
-                href="/admin/management"
-                className={
-                  pathname.includes('/management')
-                    ? 'text-[13px] font-bold md:text-[15px]'
-                    : 'text-[13px] font-bold text-gray-500 md:text-[15px]'
-                }
-              >
-                챌린지 관리
-              </Link>
-              <Link
-                href="/admin/challenges"
-                className={
-                  pathname.includes('/challenges')
-                    ? 'text-[13px] font-bold md:text-[15px]'
-                    : 'text-[13px] font-bold text-gray-500 md:text-[15px]'
-                }
-              >
-                챌린지 목록
-              </Link>
-            </>
-          )}
-        </div>
-        <div className="flex gap-4">
-          {userRole === 'member' && (
-            <>
-              <button aria-label="알림">
-                <Image
-                  src={isNoti ? notiOn : notiOff}
-                  alt={isNoti ? '알림 있음 아이콘' : '알림 없음 아이콘'}
-                  width={24}
-                  height={24}
-                />
-              </button>
-              <button aria-label="유저 프로필" onClick={handleClickProfile}>
-                <Image src={member} alt="유저 프로필" width={32} height={32} />
-              </button>
-            </>
-          )}
-          {userRole === 'admin' && (
-            <button aria-label="어드민 프로필" onClick={handleClickProfile}>
-              <Image src={admin} alt="어드민 프로필" width={32} height={32} />
-            </button>
-          )}
-          {userRole === 'guest' && (
-            <Link href="/signIn">
-              <button
-                className="h-8 w-20 rounded-[10px] border text-sm font-semibold md:h-10 md:w-[90x] md:text-base"
-                aria-label="로그인"
-              >
-                로그인
-              </button>
+    <header className="flex h-14 items-center justify-between bg-[#FFFFFF] px-4 sm:px-6 md:h-15 lg:px-8">
+      <div className="flex items-center gap-4">
+        <Logo />
+        {userRole === 'admin' && (
+          <>
+            <Link
+              href="/admin/management"
+              className={
+                pathname.includes('/management')
+                  ? 'text-[13px] font-bold md:text-[15px]'
+                  : 'text-[13px] font-bold text-gray-500 md:text-[15px]'
+              }
+            >
+              챌린지 관리
             </Link>
-          )}
-        </div>
-      </header>
-      <div className="absolute z-1 right-4 md:right-6 lg:right-8">
-        {isProfileOpen && <Profile userRole={userRole} />}
+            <Link
+              href="/admin/challenges"
+              className={
+                pathname.includes('/challenges')
+                  ? 'text-[13px] font-bold md:text-[15px]'
+                  : 'text-[13px] font-bold text-gray-500 md:text-[15px]'
+              }
+            >
+              챌린지 목록
+            </Link>
+          </>
+        )}
       </div>
-    </>
+      <div className="flex gap-4 relative" ref={profileRef}>
+        {userRole === 'member' && (
+          <>
+            <button aria-label="알림">
+              <Image
+                src={isNoti ? notiOn : notiOff}
+                alt={isNoti ? '알림 있음 아이콘' : '알림 없음 아이콘'}
+                width={24}
+                height={24}
+              />
+            </button>
+            <button aria-label="유저 프로필" onClick={handleClickProfile}>
+              <Image src={member} alt="유저 프로필" width={32} height={32} />
+            </button>
+          </>
+        )}
+        {userRole === 'admin' && (
+          <button aria-label="어드민 프로필" onClick={handleClickProfile}>
+            <Image src={admin} alt="어드민 프로필" width={32} height={32} />
+          </button>
+        )}
+        {userRole === 'guest' && (
+          <Link href="/signIn">
+            <button
+              className="h-8 w-20 rounded-[10px] border text-sm font-semibold md:h-10 md:w-[90x] md:text-base"
+              aria-label="로그인"
+            >
+              로그인
+            </button>
+          </Link>
+        )}
+        {isProfileOpen && (
+          <div className="absolute z-1 top-10 right-0">
+            <Profile userRole={userRole} />
+          </div>
+        )}
+      </div>
+    </header>
   );
 }

--- a/src/layout/Gnb.jsx
+++ b/src/layout/Gnb.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import notiOff from '@/assets/icon/ic_noti_off.svg';
 import notiOn from '@/assets/icon/ic_noti_on.svg';
 import member from '@/assets/img/profile_member.svg';
@@ -9,7 +9,7 @@ import admin from '@/assets/img/profile_admin.svg';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import Logo from './_components/Logo';
-import Profile from '@/components/dropDown/Profile';
+import Profile from '@/components/dropdown/Profile';
 import { useOutsideClick } from '@/hooks/useOutsideClick';
 
 export default function Gnb({ isNoti, userRole }) {

--- a/src/layout/_components/Logo.jsx
+++ b/src/layout/_components/Logo.jsx
@@ -1,18 +1,12 @@
-import React from "react";
-import logo from "@/assets/img/img_logo.svg";
-import Link from "next/link";
-import Image from "next/image";
+import React from 'react';
+import logo from '@/assets/img/img_logo.svg';
+import Link from 'next/link';
+import Image from 'next/image';
 
 export default function Logo({ className }) {
   return (
     <Link href="/">
-      <Image
-        src={logo}
-        alt="Docthur 로고"
-        width={80}
-        height={18}
-        className={className}
-      />
+      <Image src={logo} alt="Docthur 로고" width={80} height={18} className={`${className} md:w-30 md:h-[27px]`} />
     </Link>
   );
 }

--- a/src/lib/api/searchChallenges.js
+++ b/src/lib/api/searchChallenges.js
@@ -1,13 +1,16 @@
-//챌린지 보기 페이지에서 사용되는 fetch 입니다.
-const BASE_URL = 'http://localhost:8080/challenges';
+import { BASE_URL } from '@/constant/constant';
 
-//챌린지 목록 가져오기
+// 챌린지 목록 가져오기
 export async function getChallenges({ page = 1, pageSize = 4, category, docType, keyword }) {
-  const res = await fetch(
-    `${BASE_URL}?page=${page}&pageSize=${pageSize}&category=${category}&docType=${docType}&keyword=${keyword}`
-  );
+  const params = new URLSearchParams();
+  params.set('page', page);
+  params.set('pageSize', pageSize);
+  if (category) params.set('category', category);
+  if (docType) params.set('docType', docType);
+  if (keyword) params.set('keyword', keyword);
+
+  const res = await fetch(`${BASE_URL}/challenges?${params.toString()}`);
 
   if (!res.ok) throw new Error('챌린지 목록을 가져올 수 없습니다.');
-
   return res.json();
 }


### PR DESCRIPTION
## 변경 사항
### `GNB 프로필 드롭다운 기능` 7a9de6b52c3067446f614b6bd45460628be54f73
- 외부 또는 프로필 버튼 클릭시 프로필이 닫히도록 구현 fd3dda519a2df717dcd0ac482d9f6ac2201e4851
- ### 일반 사용자
  - 실제 유저 닉네임 반영
  - 등급: 인증 기능 추가 후 반영 예정
<img width="539" alt="image" src="https://github.com/user-attachments/assets/2572a6be-49e5-4f28-bdc8-6145f3aec20a" />

- ### 어드민
  - 전체 페이지에서 어드민 프로필로 뜨도록 수정
<img width="539" alt="image" src="https://github.com/user-attachments/assets/67a86889-a7d7-4bf4-b507-802494bc78cc" />

### `관리자 신청 관리 페이지` 6bd7cca4a29b75f8ec24ad45c99e5462dd6a838b
- 전체 챌린지 신청 목록 조회(API 연동)
- 페이지네이션 적용 
- 화면 비율 넘칠 시 스크롤 적용
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/975fde55-e394-4b7b-b50a-f5dace826b30" />

### `기타 스타일 및 라우팅 개선` 
- 로그인 시 챌린지 목록 보기로 이동
- Sort 컴포넌트 편의성을 위해 전체 버튼으로 수정 233fdff06480b5d5f403c1de683c1cb180f08656
- 로그아웃 버튼 클릭 시 accessToken, refreshToken 쿠키에서 삭제 + 로그인 페이지로 이동

