### PR TITLE
refactor: work API 호출을 클라이언트에서 서버 액션 기반으로 마이그레이션

### DIFF
--- a/src/app/(user)/challenges/[challengeId]/work/[workId]/form/_components/OriginalPageModal.jsx
+++ b/src/app/(user)/challenges/[challengeId]/work/[workId]/form/_components/OriginalPageModal.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import outCircle from "@/assets/icon/ic_out_circle.svg";
 import BtnText from "@/components/btn/text/BtnText";
 
-export default function OriginalPageModal({ pageUrl, onClose, modalState, originalPageUrl }) {
+export default function OriginalPageModal({ originalPageUrl, onClose, modalState }) {
   return (
     <div>
       {/* 모달 상태에 따라 모달 렌더링 (삼항 연산으로 한 이유는 애니메이션시 이게더 자연스럽게 나와서) */}
@@ -23,9 +23,9 @@ export default function OriginalPageModal({ pageUrl, onClose, modalState, origin
               링크 열기
             </BtnText>
           </div>
-          {pageUrl ? (
+          {originalPageUrl ? (
             <iframe
-              src={pageUrl}
+              src={originalPageUrl}
               title="원문 페이지"
               className="h-full w-full border-0"
               loading="lazy"
@@ -33,7 +33,7 @@ export default function OriginalPageModal({ pageUrl, onClose, modalState, origin
               sandbox="allow-same-origin allow-scripts allow-popups allow-forms"
             />
           ) : (
-            <div className="flex items-center justify-center h-full text-gray-500">
+            <div className="flex h-full items-center justify-center text-gray-500">
               원문 페이지를 불러올 수 없습니다.
             </div>
           )}
@@ -56,7 +56,7 @@ export default function OriginalPageModal({ pageUrl, onClose, modalState, origin
             </BtnText>
           </div>
           <iframe
-            src={pageUrl}
+            src={originalPageUrl}
             title="원문 페이지"
             className="h-full w-full border-0"
             loading="lazy"

--- a/src/app/(user)/challenges/[challengeId]/work/[workId]/form/page.jsx
+++ b/src/app/(user)/challenges/[challengeId]/work/[workId]/form/page.jsx
@@ -64,10 +64,9 @@ export default function page() {
 
       {/* 원문 페이지 모달 */}
       <OriginalPageModal
-        pageUrl={workMeta.originalUrl}
+        originalPageUrl={workMeta.originalUrl}
         onClose={() => updateModalState("isOriginalPageOpen", false)}
         modalState={modalState.isOriginalPageOpen}
-        originalPageUrl={workMeta.originalUrl}
       />
 
       {draftState.hasDraft && (

--- a/src/hooks/work/useWorkData.js
+++ b/src/hooks/work/useWorkData.js
@@ -1,6 +1,8 @@
+"use client";
+
 import { useState, useEffect } from "react";
-import workService from "@/lib/api/workService";
 import { useRouter } from "next/navigation";
+import { deleteWorkAction, getWorkDetailAction, updateWorkAction } from "@/lib/actions/work";
 
 export const useWorkData = (challengeId, updateModalState) => {
   const router = useRouter();
@@ -19,31 +21,38 @@ export const useWorkData = (challengeId, updateModalState) => {
   // 초기 데이터 로드
   useEffect(() => {
     const fetchInitialData = async () => {
-      // TODO : 현재는 테스트 코드 수정하기 버튼 완성되면 주석 해제하기
-      //   const response = await workService.getWorkDetail(challengeId, workMeta.workId);
-      const response = await workService.getWorkDetail();
-      if (response.data) {
-        setWorkMeta({
-          workId: response.data.workId,
-          challengeTitle: response.data.challengeTitle,
-          originalUrl: response.data.originalUrl
-        });
-        setContent(response.data.content);
-        setIsSubmitted(response.data.content === "");
+      try {
+        // TODO: 테스트 ID는 실제 매개변수로 교체 필요
+        // const response = await getWorkDetailAction(challengeId, workMeta.workId);
+        const response = await getWorkDetailAction(15, 67);
+        if (response?.data) {
+          setWorkMeta({
+            workId: response.data.workId,
+            challengeTitle: response.data.challengeTitle,
+            originalUrl: response.data.originalUrl
+          });
+          setContent(response.data.content);
+          setIsSubmitted(response.data.content === "");
+        }
+      } catch (error) {
+        console.error("작업물 상세 조회 실패:", error.message);
       }
     };
+
     fetchInitialData();
   }, []);
 
   // 작업물 업데이트
   const handleUpdateWork = async () => {
     try {
-      await workService.updateWork(workMeta.workId, content === "<p></p>" ? "" : content);
+      const payload = content === "<p></p>" ? "" : content;
+      // await updateWorkAction(workMeta.workId, payload);
+      await updateWorkAction(67, payload);
       updateModalState("isSubmitConfirmOpen", false);
       router.refresh();
       return true;
     } catch (error) {
-      console.error("작업물 업데이트 실패:", error);
+      console.error("작업물 업데이트 실패:", error.message);
       return false;
     }
   };
@@ -51,15 +60,16 @@ export const useWorkData = (challengeId, updateModalState) => {
   // 작업물 삭제
   const handleDeleteWork = async () => {
     try {
-      const deleteResult = await workService.deleteWork(workMeta.workId);
-      if (deleteResult.status === 204) {
+      // const result = await deleteWorkAction(workMeta.workId);
+      const result = await deleteWorkAction(67);
+      if (result.status === 204) {
         updateModalState("isDeleteConfirmOpen", false);
         router.push(`/challenges/${challengeId}`);
         return true;
       }
       return false;
     } catch (error) {
-      console.error("작업물 삭제 실패:", error);
+      console.error("작업물 삭제 실패:", error.message);
       return false;
     }
   };

--- a/src/lib/actions/work.js
+++ b/src/lib/actions/work.js
@@ -1,0 +1,131 @@
+"use server";
+
+import { cookies } from "next/headers";
+
+const BASE_URL = process.env.NODE_ENV === "production" ? process.env.NEXT_PUBLIC_API_URL : "http://localhost:8080";
+
+// accessToken을 안전하게 추출
+const getAccessToken = async () => {
+  const cookieStore = await cookies(); // 동기
+  const token = cookieStore.get("accessToken"); // 동기
+  return token?.value;
+};
+
+// fetch 요청에 사용할 headers 구성
+const getAuthHeaders = async () => {
+  const accessToken = await getAccessToken(); // 반드시 await 필요
+  return {
+    "Content-Type": "application/json",
+    Cookie: `accessToken=${accessToken}`
+  };
+};
+
+// ✅ 작업물 상세 조회
+export async function getWorkDetailAction(challengeId, workId) {
+  const headers = await getAuthHeaders();
+
+  const res = await fetch(`${BASE_URL}/challenges/${challengeId}/works/${workId}`, {
+    method: "GET",
+    headers,
+    credentials: "include",
+    cache: "no-store"
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`작업물 조회 실패 (${res.status}): ${text}`);
+  }
+
+  return await res.json();
+}
+
+// ✅ 작업물 생성
+export async function createWorkAction(challengeId) {
+  const headers = await getAuthHeaders();
+
+  const res = await fetch(`${BASE_URL}/challenges/${challengeId}/works`, {
+    method: "POST",
+    headers,
+    credentials: "include",
+    cache: "no-store"
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`작업물 생성 실패 (${res.status}): ${text}`);
+  }
+
+  return await res.json();
+}
+
+// ✅ 작업물 수정
+export async function updateWorkAction(workId, content) {
+  const headers = await getAuthHeaders();
+
+  const res = await fetch(`${BASE_URL}/works/${workId}`, {
+    method: "PATCH",
+    headers,
+    credentials: "include",
+    cache: "no-store",
+    body: JSON.stringify({ content })
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`작업물 수정 실패 (${res.status}): ${text}`);
+  }
+
+  return await res.json();
+}
+
+// ✅ 작업물 삭제
+export async function deleteWorkAction(workId) {
+  const headers = await getAuthHeaders();
+
+  const res = await fetch(`${BASE_URL}/works/${workId}`, {
+    method: "DELETE",
+    headers,
+    credentials: "include",
+    cache: "no-store"
+  });
+
+  return { status: res.status };
+}
+
+// ✅ 작업물 좋아요 생성
+export async function createWorkLikeAction(workId) {
+  const headers = await getAuthHeaders();
+
+  const res = await fetch(`${BASE_URL}/works/${workId}/like`, {
+    method: "POST",
+    headers,
+    credentials: "include",
+    cache: "no-store"
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`좋아요 실패 (${res.status}): ${text}`);
+  }
+
+  return await res.json();
+}
+
+// ✅ 작업물 좋아요 삭제
+export async function deleteWorkLikeAction(workId) {
+  const headers = await getAuthHeaders();
+
+  const res = await fetch(`${BASE_URL}/works/${workId}/like`, {
+    method: "DELETE",
+    headers,
+    credentials: "include",
+    cache: "no-store"
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`좋아요 취소 실패 (${res.status}): ${text}`);
+  }
+
+  return await res.json();
+}

--- a/src/lib/api/workService.js
+++ b/src/lib/api/workService.js
@@ -5,8 +5,7 @@ const BASE_URL = process.env.NODE_ENV === "production" ? process.env.NEXT_PUBLIC
 const fetchConfig = {
   credentials: "include",
   headers: {
-    "Content-Type": "application/json",
-    Origin: process.env.NEXT_PUBLIC_CLIENT_URL // 프론트엔드 도메인
+    "Content-Type": "application/json"
   },
   mode: "cors"
 };


### PR DESCRIPTION
## 📌 PR 제목
refactor: useWorkData 훅의 API 호출을 서버 액션 기반으로 마이그레이션

---

## 📝 개요

- 기존 `useWorkData` 훅에서 사용하던 클라이언트 측 fetch 기반 `workService`를 제거하고,  
  Next.js App Router의 **서버 액션(Server Actions)** 기반 API 호출 구조로 리팩터링했습니다.

- 인증 쿠키(`accessToken`)를 안전하게 `cookies()`에서 읽어 fetch 요청에 포함하도록 수정했습니다.

---

## 🔧 주요 변경 사항

| 항목 | 변경 전 | 변경 후 |
|------|---------|---------|
| API 호출 방식 | 클라이언트에서 직접 fetch | 서버 액션을 통한 호출 |
| 인증 처리 방식 | credentials: "include" | `cookies().get("accessToken")`로 직접 설정 |
| 코드 구조 | `lib/api/workService.js` | `lib/actions/work.js` |
| 훅 내부 로직 | 클라이언트 fetch 의존 | 서버 액션 호출로 변경 |

### 변경 상세

- `getWorkDetail`, `updateWork`, `deleteWork`, `createWorkLike`, `deleteWorkLike` 등 모두 서버 액션으로 이동
- `useWorkData` 훅에서 서버 액션 호출하도록 수정
- 쿠키를 안전하게 읽기 위해 `await cookies()` 적용
- Prisma 에러 (`Argument 'id' is missing`) 방지를 위해 `workId` 전달 방식 개선

---

## ✅ 테스트 방법

1. `/challenges/[challengeId]/work/[workId]/form` 페이지 접속
2. 기존 작업물 데이터를 정상적으로 불러오는지 확인
3. 수정 후 제출 시 서버에서 정상 반영되는지 확인 (`updateWorkAction`)
4. 삭제 시 `204` 응답 반환 확인 및 페이지 리디렉션 (`deleteWorkAction`)
5. Network 탭에 fetch 요청이 안 보이는지 확인 (서버 액션은 클라이언트 fetch가 아님)

---

## ⚠️ 주의사항

- `cookies()` 사용 시 `await`이 필요하지 않은 것처럼 보이지만, Next.js 최신 버전에서 경고가 발생할 수 있으므로 `await cookies()`로 사용

---

## 📎 관련 이슈

- 서버 액션으로 마이그레이션 시 쿠키 누락 문제 해결

---

## 🙋‍♀️ 리뷰어에게 요청

- 서버 액션 구조가 명확하게 분리되어 있는지 확인 부탁드립니다.
- `lib/actions/work.js`의 공통 로직 구조화(예: getAuthHeaders) 리뷰 부탁드립니다.
