### PR TITLE
feat: 작업물 헤더에 어드민 드롭다운(수정,삭제) 구현

### DIFF
--- a/src/app/(user)/challenges/[challengeId]/work/[workId]/_components/Header.jsx
+++ b/src/app/(user)/challenges/[challengeId]/work/[workId]/_components/Header.jsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useParams } from "next/navigation";
 import NextjsChip from "@/components/chip/chipType/NextjsChip";
 import ApiChip from "@/components/chip/chipType/ApiChip";
@@ -11,6 +11,10 @@ import OfficialDocChip from "@/components/chip/chipCategory/OfficialDocChip";
 import Menu from "./Menu";
 import { useAuth } from "@/providers/AuthProvider";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
+import dropdownIcon from "@/assets/icon/ic_menu.svg";
+import DeclineModal from "@/components/modal/DeclineModal";
+import { deleteChallengeAction } from "@/lib/actions/challenge";
 
 const categoryComponentMap = {
   "Next.js": NextjsChip,
@@ -31,8 +35,14 @@ export default function Header() {
   const workId = params.workId;
   const [challenge, setChallenge] = useState(null);
   const [work, setWork] = useState(null);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [isDeclineModalOpen, setIsDeclineModalOpen] = useState(false);
   const { user } = useAuth();
+  const dropdownRef = useRef(null);
   const router = useRouter();
+
+  const isAdmin = user?.role === "ADMIN";
+  const isAuthor = work?.authorId === user;
 
   useEffect(() => {
     const fetchChallenge = async () => {
@@ -66,7 +76,18 @@ export default function Header() {
     fetchWork();
   }, [workId]);
 
-  const isAuthor = work?.authorId === user;
+  // 외부 클릭 시 드롭다운 닫기
+  useEffect(() => {
+    function handleClickOutside(event) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setIsDropdownOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [dropdownRef]);
 
   // 수정
   const handleEdit = () => {
@@ -90,23 +111,82 @@ export default function Header() {
     }
   };
 
+  const handleAdminEdit = () => {
+    router.push(`/challenges/${challengeId}/work/${workId}/form`);
+    setIsDropdownOpen(false);
+  };
+
+  const handleAdminDelete = () => {
+    setIsDeclineModalOpen(true);
+    setIsDropdownOpen(false);
+  };
+
+  const handleCloseDeclineModal = () => {
+    setIsDeclineModalOpen(false);
+  };
+
+  const handleConfirmDelete = async (adminMessage) => {
+    try {
+      await deleteChallengeAction(challengeId, adminMessage);
+      // 삭제 성공 시, 해당 챌린지 페이지로 이동
+      router.push(`/challenges/${challengeId}`);
+    } catch (error) {
+      console.error("챌린지 삭제 실패:", error);
+      alert("챌린지 삭제에 실패했습니다: " + error.message);
+    }
+  };
+
   return (
     <div>
       <div className="flex justify-between">
         <div className="mb-4 text-xl font-semibold text-gray-800 md:text-2xl">{challenge?.title || "Loading..."}</div>
         {isAuthor && <Menu onEdit={handleEdit} onDelete={handleDelete} />}
       </div>
-      <div className="flex items-center gap-2">
-        {/*카테고리 칩*/}
-        {challenge?.category &&
-          categoryComponentMap[challenge.category] &&
-          React.createElement(categoryComponentMap[challenge.category])}
+      <div className="flex items-center gap-2 justify-between">
+        <div className="flex items-center gap-2">
+          {/*카테고리 칩*/}
+          {challenge?.category &&
+            categoryComponentMap[challenge.category] &&
+            React.createElement(categoryComponentMap[challenge.category])}
 
-        {/*문서 타입 칩*/}
-        {challenge?.docType &&
-          docTypeComponentMap[challenge.docType] &&
-          React.createElement(docTypeComponentMap[challenge.docType])}
+          {/*문서 타입 칩*/}
+          {challenge?.docType &&
+            docTypeComponentMap[challenge.docType] &&
+            React.createElement(docTypeComponentMap[challenge.docType])}
+        </div>
+
+        {/* 어드민 모달 */}
+        {isAdmin ? (
+          <div ref={dropdownRef} className="relative">
+            <button onClick={() => setIsDropdownOpen(!isDropdownOpen)}>
+              <Image src={dropdownIcon} alt="드롭다운" width={24} height={24} />
+            </button>
+            {isDropdownOpen && (
+              <div className="absolute right-0 top-full z-10 mt-2 w-28 rounded-md border border-gray-200 bg-white shadow-lg">
+                <button
+                  onClick={handleAdminEdit}
+                  className="block w-full px-4 py-2 text-center text-sm text-gray-700 hover:bg-gray-100"
+                >
+                  수정하기
+                </button>
+                <button
+                  onClick={handleAdminDelete}
+                  className="block w-full px-4 py-2 text-center text-sm text-gray-700 hover:bg-gray-100"
+                >
+                  삭제하기
+                </button>
+              </div>
+            )}
+          </div>
+        ) : null}
       </div>
+      {isDeclineModalOpen && (
+        <DeclineModal
+          text="삭제"
+          onClose={handleCloseDeclineModal}
+          onConfirm={handleConfirmDelete}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/card/Card.jsx
+++ b/src/components/card/Card.jsx
@@ -8,7 +8,7 @@ import { typeChipMap, categoryChipMap } from "../chip/chipMaps";
 import ChipCardStatus from "@/components/chip/chipComplete/ChipCardStatus";
 import { useEffect, useState, useRef } from "react";
 import { useRouter } from "next/navigation";
-import DeclineModal from "../modal/DeclineModal";
+import DeclineModal from "@/components/modal/DeclineModal";
 import { deleteChallengeAction } from "@/lib/actions/challenge";
 
 export default function ChallengeCard({


### PR DESCRIPTION
### 작업물 헤더에 어드민 드롭다운(수정,삭제) 구현했으며, Card컴포넌트의 거절모달 임포트를 절대경로로 개선했습니다.

---
로그인한 사용자가 `어드민`일때, 작업물 수정 삭제 드롭다운이 표시됩니다.
- 수정하기 누르면 작업물 폼으로 이동하며, 삭제하기 누르면 모달 통해 거절사유 입력하고 삭제 후, 해당 챌린지ID로 이동합니다.
![image](https://github.com/user-attachments/assets/aecf7f25-cca4-43b9-a272-40d163fcc164)
