### PR TITLE
fix: 배포환경에서 리스트 불러오지 못하는 이슈 해결

### DIFF
--- a/src/app/(user)/challenges/my/_components/MyChallenges.jsx
+++ b/src/app/(user)/challenges/my/_components/MyChallenges.jsx
@@ -5,6 +5,7 @@ import SearchInput from "@/components/input/SearchInput";
 import ChallengeCard from "@/components/card/Card";
 import useChallenges from "@/hooks/useChallengeList";
 export default function Mychallenges({myChallengeStatus}) {
+  console.log("🧩 Mychallenges 컴포넌트 렌더", myChallengeStatus);
   
   const {
     challenges,

--- a/src/app/(user)/challenges/my/complete/page.jsx
+++ b/src/app/(user)/challenges/my/complete/page.jsx
@@ -7,7 +7,7 @@ export default function CompletedChallengesPage() {
    const { loading } = useAuth();
   
   if (loading) return <div>로딩 중...</div>;
-    console.log(`요청 url`)
+    
     return (
       <Mychallenges myChallengeStatus="completed" />
     )

--- a/src/app/(user)/challenges/page.jsx
+++ b/src/app/(user)/challenges/page.jsx
@@ -6,17 +6,27 @@ import SearchInput from "@/components/input/SearchInput";
 import ChallengeCard from "@/components/card/Card";
 import FilterModal from "@/components/modal/FilterModal";
 import Pagination from "@/components/pagination/Pagination";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import useChallenges from "@/hooks/useChallengeList";
 import { useAuth } from "@/providers/AuthProvider";
 import { useRouter } from "next/navigation";
 
 function Page() {
+
+  const [shouldFetch, setShouldFetch] = useState(false);
+  const { user, isLoading: authLoading } = useAuth(); // authLoading 추가
+
+  useEffect(() => {
+    if (!authLoading && user) {
+      setShouldFetch(true); // 로그인 상태 확인 후에만 데이터 패칭
+    }
+  }, [user, authLoading]);
+
+
   const [isModal, setIsModal] = useState(false);
   const router = useRouter();
 
   //현재 사용자가 일반유저인지, 관리자인지 확인
-  const { user } = useAuth();
   const isAdmin = user?.role === "ADMIN";
 
   //디버깅
@@ -41,7 +51,7 @@ function Page() {
     setPage,
     setKeyword,
     applyFilters
-  } = useChallenges();
+  } = useChallenges({ enabled: shouldFetch }); // 훅 내부에서 enabled로 조건 제어
 
   const handleClickFilter = () => {
     setIsModal(true);
@@ -55,6 +65,8 @@ function Page() {
     applyFilters(newFilters);
     setIsModal(false);
   };
+
+  const isInitialLoading = isLoading && page === 1 && challenges.length === 0;
 
   // //검색에서 초성만 문자열로 뽑아냄
   // const getInitials = (text) => {
@@ -113,7 +125,7 @@ function Page() {
       </div>
 
       <div className="flex flex-col gap-[24px] py-[24px]">
-        {isLoading ? (
+        {isInitialLoading ? (
           <div className="flex text-[var(--color-gray-500)] flex-col w-full h-full justify-center items-center text-[16px] font-medium font-pretendard">
             챌린지 목록을 불러오는 중...
           </div>

--- a/src/hooks/useChallengeList.js
+++ b/src/hooks/useChallengeList.js
@@ -1,8 +1,11 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { getChallenges } from "@/lib/api/challenge-api/searchChallenge";
+import { useAuth } from "@/providers/AuthProvider";
 
-const useChallenges = () => {
+const useChallenges = (myChallengeStatus="") => {
+
+  const { user } = useAuth();
   const [filters, setFilters] = useState({
     categories: [],
     docType: "",
@@ -20,6 +23,7 @@ const useChallenges = () => {
   const { categories, docType, status } = filters;
 
   const getChallengesData = useCallback(async () => {
+
     setIsLoading(true);
     setError(null);
     try {
@@ -29,12 +33,13 @@ const useChallenges = () => {
         keyword,
         category: filters.categories[0] || "",
         docType: filters.docType,
-        status: filters.status
+        status: filters.status,
+        myChallengeStatus,
       };
 
-      const challengesResults = await getChallenges(options);
+      const challengesResults = await getChallenges(options) ?? { data: [], totalCount: 0 };
       setTotalCount(challengesResults.totalCount);
-      const results = challengesResults.data;
+      const results = Array.isArray(challengesResults?.data) ? challengesResults.data : [];
 
       const currentDate = new Date();
 
@@ -57,9 +62,11 @@ const useChallenges = () => {
     } finally {
       setIsLoading(false);
     }
-  }, [page, pageSize, keyword, categories, docType, status]);
+  }, [user, page, pageSize, keyword, categories, docType, status]);
 
   useEffect(() => {
+    console.log("user or getChallengesData changed", user, getChallengesData);
+     if (!user) return; // 로그인 안 되어 있으면 실행 X
     getChallengesData();
   }, [getChallengesData]);
 


### PR DESCRIPTION
- 배포환경에서 챌린지 리스트를 불러오지 못하는 이슈가 있었음
- 처음에는 의존성 배열 셋팅을 의심
- 로그로 확인해보니 유저정보를 제대로 전달하지 못하고 있었음 (비동기 이슈)
- useChallenges 훅이 실행되어도 getChallengesData가 내부에서 조기 종료되어 undefined 반환
- 해결했는데도 제대로된 api를 요청하지 못하고 있었음
- 이 api는 나의 챌린지 상태값을 string으로 정의하고 넘겨주고 있었는데 공백일 경우에도 나의챌린지 api를 사용하고 있었음
- `typeof myChallengeStatus === "string" && myChallengeStatus.trim() !== "";` 를 변수로 정의하고 이 값이 true 일 경우에만 나의챌린지 api 사용하도록 정의