### PR TITLE
feat:챌린지 목록>필터 시 상태(진행중/마감) 오류 수정

### DIFF
--- a/src/app/(user)/challenges/my/_components/MyChallenges.jsx
+++ b/src/app/(user)/challenges/my/_components/MyChallenges.jsx
@@ -5,19 +5,9 @@ import SearchInput from "@/components/input/SearchInput";
 import ChallengeCard from "@/components/card/Card";
 import Pagination from "@/components/pagination/Pagination";
 import useChallenges from "@/hooks/useChallengeList";
-export default function Mychallenges({children, myChallengeStatus}) {
-  
-  const {
-    challenges,
-    totalCount,
-    page,
-    pageSize,
-    keyword,
-    isLoading,
-    error,
-    setPage,
-    setKeyword,
-  } = useChallenges(myChallengeStatus);
+export default function Mychallenges({ children, myChallengeStatus }) {
+  const { challenges, totalCount, page, pageSize, keyword, isLoading, error, setPage, setKeyword } =
+    useChallenges(myChallengeStatus);
 
   const handleScroll = useCallback(() => {
     if (
@@ -30,21 +20,19 @@ export default function Mychallenges({children, myChallengeStatus}) {
     }
   }, [isLoading, challenges.length, totalCount, setPage]);
 
-   useEffect(() => {
+  useEffect(() => {
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
   }, [handleScroll]);
 
   return (
     <>
-      <SearchInput
-            text={"text-[14px]"}
-            value={keyword}
-            onChange={(e) => setKeyword(e.target.value)}
-          />
+      <SearchInput text={"text-[14px]"} value={keyword} onChange={(e) => setKeyword(e.target.value)} />
       <div className="flex flex-col gap-[24px] py-[24px]">
         {isLoading ? (
-          <div className="text-sm w-full h-full flex items-center justify-center text-gray-500">챌린지 목록을 불러오는 중...</div>
+          <div className="flex h-full w-full items-center justify-center text-sm text-gray-500">
+            챌린지 목록을 불러오는 중...
+          </div>
         ) : error ? (
           <div className="text-red-500">{error}</div>
         ) : challenges.length > 0 ? (
@@ -60,7 +48,9 @@ export default function Mychallenges({children, myChallengeStatus}) {
             />
           ))
         ) : (
-          <div className="text-sm w-full h-full flex items-center justify-center text-gray-500">챌린지가 존재하지 않습니다.</div>
+          <div className="flex h-full w-full items-center justify-center text-sm text-gray-500">
+            챌린지가 존재하지 않습니다.
+          </div>
         )}
       </div>
 
@@ -70,7 +60,6 @@ export default function Mychallenges({children, myChallengeStatus}) {
         pageSize={pageSize}
         onPageChange={(newPage) => setPage(newPage)}
       /> */}
-
-    </>  
+    </>
   );
 }

--- a/src/app/(user)/challenges/my/page.jsx
+++ b/src/app/(user)/challenges/my/page.jsx
@@ -3,7 +3,5 @@
 import Mychallenges from "./_components/MyChallenges";
 
 export default function ParticipatedChallengesPage() {
-  return (
-    <Mychallenges myChallengeStatus="participated" />
-  )
+  return <Mychallenges myChallengeStatus="participated" />;
 }

--- a/src/app/(user)/challenges/page.jsx
+++ b/src/app/(user)/challenges/page.jsx
@@ -12,7 +12,6 @@ import { useAuth } from "@/providers/AuthProvider";
 import { useRouter } from "next/navigation";
 
 function Page() {
-
   const [shouldFetch, setShouldFetch] = useState(false);
   const { user, isLoading: authLoading } = useAuth(); // authLoading 추가
 
@@ -21,7 +20,6 @@ function Page() {
       setShouldFetch(true); // 로그인 상태 확인 후에만 데이터 패칭
     }
   }, [user, authLoading]);
-
 
   const [isModal, setIsModal] = useState(false);
   const router = useRouter();
@@ -66,9 +64,8 @@ function Page() {
     setIsModal(false);
   };
 
-
   return (
-    <div className="mx-[16px] [@media(min-width:1200px)]:mx-[462px] mt-[16px] mb-[65px]">
+    <div className="mx-[16px] mt-[16px] mb-[65px] [@media(min-width:1200px)]:mx-[462px]">
       <div className="font-pretendard flex flex-row items-center justify-between text-[20px] font-semibold">
         챌린지 목록 <ApplyChallenge />
       </div>
@@ -92,8 +89,8 @@ function Page() {
       </div>
 
       <div className="flex flex-col gap-[24px] py-[24px]">
-        {isInitialLoading ? (
-          <div className="flex text-[var(--color-gray-500)] flex-col w-full h-full justify-center items-center text-[16px] font-medium font-pretendard">
+        {isLoading ? (
+          <div className="font-pretendard flex h-full w-full flex-col items-center justify-center text-[16px] font-medium text-[var(--color-gray-500)]">
             챌린지 목록을 불러오는 중...
           </div>
         ) : error ? (
@@ -114,7 +111,7 @@ function Page() {
             </div>
           ))
         ) : (
-          <div className="flex text-[var(--color-gray-500)] flex-col w-full h-full justify-center items-center text-[16px] font-medium font-pretendard">
+          <div className="font-pretendard flex h-full w-full flex-col items-center justify-center text-[16px] font-medium text-[var(--color-gray-500)]">
             <div>아직 챌린지가 없어요.</div>
             <div>지금 바로 챌린지를 신청해보세요!</div>
           </div>

--- a/src/app/(user)/challenges/page.jsx
+++ b/src/app/(user)/challenges/page.jsx
@@ -56,38 +56,6 @@ function Page() {
     setIsModal(false);
   };
 
-  // //검색에서 초성만 문자열로 뽑아냄
-  // const getInitials = (text) => {
-  //   if (!text) return "";
-  //   return Hangul.d(text, true)
-  //     .map(([initial]) => initial)
-  //     .join(""); //>"ㅊㄹㄷ"
-  // };
-
-  // //검색어가 이미 초성인지 확인 Boolean 리턴
-  // const isInitialsOnly = (text) => {
-  //   return /^[ㄱ-ㅎ]+$/.test(text);
-  // };
-
-  //띄어쓰기 잘못해도 검색 가능하도록
-  // const filteredChallenges = useMemo(() => {
-  //   if (!keyword) return challenges;
-
-  //   const trimmedKeyword = keyword.trim();
-
-  //   const includeKeywordChallenges = challenges.filter((challenge) => {
-  //     return challenge.title.includes(trimmedKeyword);
-  //   });
-
-  //   return includeKeywordChallenges;
-  // }, [challenges, keyword]);
-
-  // //띄어뜨시 잘못해도 검색 가능 하도록
-  // const trimmedKeyword = () => (keyword ? keyword.trim() : "");
-
-  //디버깅
-  console.log("challenges", challenges);
-
   return (
     <div className="mx-[16px] mt-[16px] mb-[65px] [@media(min-width:1200px)]:mx-[462px]">
       <div className="font-pretendard flex flex-row items-center justify-between text-[20px] font-semibold">
@@ -130,6 +98,7 @@ function Page() {
                 deadline={challenge.deadline}
                 participants={challenge.participants.length}
                 maxParticipant={challenge.maxParticipant}
+                // status={challenge.status}
                 isAdmin={isAdmin}
                 onClick={() => handleClickCard(challenge.id)}
               />

--- a/src/components/card/Card.jsx
+++ b/src/components/card/Card.jsx
@@ -19,6 +19,7 @@ export default function ChallengeCard({
   deadline,
   participants,
   maxParticipant,
+  // status,
   variant = "default",
   isAdmin,
   onClick
@@ -28,7 +29,7 @@ export default function ChallengeCard({
   const [isDeclineModalOpen, setIsDeclineModalOpen] = useState(false);
   const dropdownRef = useRef(null);
 
-  const router = useRouter()
+  const router = useRouter();
 
   useEffect(() => {
     const now = new Date();
@@ -60,12 +61,12 @@ export default function ChallengeCard({
     return new Intl.DateTimeFormat("ko-KR", {
       year: "numeric",
       month: "long",
-      day: "numeric",
+      day: "numeric"
     }).format(date);
   };
 
   const handleEdit = () => {
-    router.push(`/admin/challenges/${challengeId}/edit`)
+    router.push(`/admin/challenges/${challengeId}/edit`);
     setIsDropdownOpen(false);
   };
 
@@ -89,18 +90,20 @@ export default function ChallengeCard({
     }
   };
 
+  //디버깅
+  console.log("status", status);
+
   return (
     <div
-      className={`flex flex-col 
-      ${variant === "simple" ? "h-auto justify-start" : "h-[227px] justify-between sm:h-[262px] md:h-[225px]"}
-      ${variant === "simple" ? "" : "rounded-[12px] border-2 border-[var(--color-gray-800)]"}
-      bg-white p-4`}
+      className={`flex flex-col ${variant === "simple" ? "h-auto justify-start" : "h-[227px] justify-between sm:h-[262px] md:h-[225px]"} ${variant === "simple" ? "" : "rounded-[12px] border-2 border-[var(--color-gray-800)]"} bg-white p-4`}
     >
       <div className="relative flex items-start justify-between">
         {status ? (
           <ChipCardStatus status={status} />
         ) : (
-          <div className="text-xl font-semibold text-gray-800" onClick={onClick}>{title}</div>
+          <div className="text-xl font-semibold text-gray-800" onClick={onClick}>
+            {title}
+          </div>
         )}
         {isAdmin ? (
           <div ref={dropdownRef}>
@@ -108,7 +111,7 @@ export default function ChallengeCard({
               <Image src={dropdownIcon} alt="드롭다운" width={24} height={24} />
             </button>
             {isDropdownOpen && (
-              <div className="absolute right-0 top-full z-10 mt-2 w-28 rounded-md border border-gray-200 bg-white shadow-lg">
+              <div className="absolute top-full right-0 z-10 mt-2 w-28 rounded-md border border-gray-200 bg-white shadow-lg">
                 <button
                   onClick={handleEdit}
                   className="block w-full px-4 py-2 text-center text-sm text-gray-700 hover:bg-gray-100"
@@ -127,7 +130,11 @@ export default function ChallengeCard({
         ) : null}
       </div>
 
-      {status && <div className="mt-2 text-xl font-semibold text-gray-800" onClick={onClick}>{title}</div>}
+      {status && (
+        <div className="mt-2 text-xl font-semibold text-gray-800" onClick={onClick}>
+          {title}
+        </div>
+      )}
 
       <div className="mt-2 flex flex-wrap gap-2">
         {categoryChipMap[category] ?? null}
@@ -155,11 +162,7 @@ export default function ChallengeCard({
         </>
       )}
       {isDeclineModalOpen && (
-        <DeclineModal
-          text="삭제"
-          onClose={handleCloseDeclineModal}
-          onConfirm={handleConfirmDelete}
-        />
+        <DeclineModal text="삭제" onClose={handleCloseDeclineModal} onConfirm={handleConfirmDelete} />
       )}
     </div>
   );

--- a/src/components/modal/FilterModal.jsx
+++ b/src/components/modal/FilterModal.jsx
@@ -8,17 +8,17 @@ const FIELD_OPTIONS = [
   { label: "Modern JS", value: "Modern JS" },
   { label: "API", value: "API" },
   { label: "Web", value: "Web" },
-  { label: "Career", value: "Career" },
+  { label: "Career", value: "Career" }
 ];
 
 const DOC_TYPE_OPTIONS = [
   { label: "공식문서", value: "공식문서" },
-  { label: "블로그", value: "블로그" },
+  { label: "블로그", value: "블로그" }
 ];
 
 const STATUS_OPTIONS = [
-  { label: "진행중", value: "progress" },
-  { label: "마감", value: "closed" },
+  { label: "진행중", value: "open" },
+  { label: "마감", value: "closed" }
 ];
 
 export default function FilterModal({
@@ -27,7 +27,7 @@ export default function FilterModal({
   initialStatus = "",
   onApply,
   onReset,
-  onClose,
+  onClose
 }) {
   const [fields, setFields] = useState(initialFields);
   const [docType, setDocType] = useState(initialDocType);
@@ -35,9 +35,7 @@ export default function FilterModal({
 
   // 체크박스 토글
   const toggleField = (value) => {
-    setFields((prev) =>
-      prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value],
-    );
+    setFields((prev) => (prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value]));
   };
 
   // 리셋
@@ -69,10 +67,7 @@ export default function FilterModal({
           <div className="mb-3 text-sm font-semibold text-gray-800">분야</div>
           <div className="flex flex-col gap-2">
             {FIELD_OPTIONS.map((option) => (
-              <label
-                key={option.value}
-                className="relative flex cursor-pointer items-center gap-2 select-none"
-              >
+              <label key={option.value} className="relative flex cursor-pointer items-center gap-2 select-none">
                 <input
                   type="checkbox"
                   checked={fields.includes(option.value)}
@@ -82,23 +77,12 @@ export default function FilterModal({
                 />
                 <span
                   className={`flex h-5 w-5 items-center justify-center rounded-md border-2 transition ${
-                    fields.includes(option.value)
-                      ? "border-black bg-black"
-                      : "border-gray-300 bg-white"
+                    fields.includes(option.value) ? "border-black bg-black" : "border-gray-300 bg-white"
                   } `}
                 >
                   {fields.includes(option.value) && (
-                    <svg
-                      className="pointer-events-none h-3 w-3 text-white"
-                      viewBox="0 0 12 10"
-                      fill="none"
-                    >
-                      <path
-                        d="M1 5.5L4.5 9L11 1"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                      />
+                    <svg className="pointer-events-none h-3 w-3 text-white" viewBox="0 0 12 10" fill="none">
+                      <path d="M1 5.5L4.5 9L11 1" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
                     </svg>
                   )}
                 </span>
@@ -110,15 +94,10 @@ export default function FilterModal({
 
         {/* 문서 타입 */}
         <div className="border-y-1 border-solid border-gray-200 px-6 py-3">
-          <div className="mb-3 text-sm font-semibold text-gray-800">
-            문서 타입
-          </div>
+          <div className="mb-3 text-sm font-semibold text-gray-800">문서 타입</div>
           <div className="flex flex-col gap-2">
             {DOC_TYPE_OPTIONS.map((option) => (
-              <label
-                key={option.value}
-                className="relative flex cursor-pointer items-center gap-2 select-none"
-              >
+              <label key={option.value} className="relative flex cursor-pointer items-center gap-2 select-none">
                 <input
                   type="radio"
                   name="docType"
@@ -129,14 +108,10 @@ export default function FilterModal({
                 />
                 <span
                   className={`flex h-5 w-5 items-center justify-center rounded-full border-2 transition ${
-                    docType === option.value
-                      ? "border-black bg-black"
-                      : "border-gray-300 bg-white"
+                    docType === option.value ? "border-black bg-black" : "border-gray-300 bg-white"
                   } `}
                 >
-                  {docType === option.value && (
-                    <span className="block h-2.5 w-2.5 rounded-full bg-white" />
-                  )}
+                  {docType === option.value && <span className="block h-2.5 w-2.5 rounded-full bg-white" />}
                 </span>
                 <span className="text-sm text-gray-800">{option.label}</span>
               </label>
@@ -149,10 +124,7 @@ export default function FilterModal({
           <div className="mb-3 text-sm font-semibold text-gray-800">상태</div>
           <div className="flex flex-col gap-2">
             {STATUS_OPTIONS.map((option) => (
-              <label
-                key={option.value}
-                className="relative flex cursor-pointer items-center gap-2 select-none"
-              >
+              <label key={option.value} className="relative flex cursor-pointer items-center gap-2 select-none">
                 <input
                   type="radio"
                   name="status"
@@ -163,14 +135,10 @@ export default function FilterModal({
                 />
                 <span
                   className={`flex h-5 w-5 items-center justify-center rounded-full border-2 transition ${
-                    status === option.value
-                      ? "border-black bg-black"
-                      : "border-gray-300 bg-white"
+                    status === option.value ? "border-black bg-black" : "border-gray-300 bg-white"
                   } `}
                 >
-                  {status === option.value && (
-                    <span className="block h-2.5 w-2.5 rounded-full bg-white" />
-                  )}
+                  {status === option.value && <span className="block h-2.5 w-2.5 rounded-full bg-white" />}
                 </span>
                 <span className="text-sm text-gray-800">{option.label}</span>
               </label>

--- a/src/hooks/useChallengeList.js
+++ b/src/hooks/useChallengeList.js
@@ -11,7 +11,15 @@ const useChallenges = (myChallengeStatus) => {
   const [keyword, setKeyword] = useState("");
   const [totalCount, setTotalCount] = useState(0);
   const [page, setPage] = useState(1);
-  const [pageSize, setPageSize] = useState(4);
+
+  const getInitialPageSize = () => {
+    if (typeof window !== "undefined") {
+      return window.innerWidth > 375 ? 5 : 4;
+    }
+    return 4;
+  };
+
+  const [pageSize, setPageSize] = useState(getInitialPageSize);
   const [filterCount, setFilterCount] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -34,68 +42,23 @@ const useChallenges = (myChallengeStatus) => {
       setTotalCount(challengesResults.totalCount);
       const results = challengesResults.data;
 
-      const currentDate = new Date();
-
-      let filteredResults = results;
-      if (filters.status === "progress") {
-        filteredResults = results.filter((result) => {
-          const deadlineDate = new Date(result.deadline);
-          return deadlineDate.getTime() > currentDate.getTime();
-        });
-      } else if (filters.status === "closed") {
-        filteredResults = results.filter((result) => {
-          const deadlineDate = new Date(result.deadline);
-          return deadlineDate.getTime() < currentDate.getTime();
-        });
-      }
-      console.log(filteredResults)
-      if (page === 1) {
-        setChallenges(filteredResults);
-      } else {
-        setChallenges((prev) => [...prev, ...filteredResults]);
-      }
+      setChallenges(results);
     } catch (err) {
       console.error("챌린지 목록 불러오기 실패:", err);
       setError("챌린지 목록을 불러오는 데 실패했습니다.");
-      setChallenges([]); 
+      setChallenges([]);
     } finally {
       setIsLoading(false);
     }
-  }, [
-      page,
-      pageSize,
-      keyword,
-      filters.categories,
-      filters.docType,
-      filters.status,
-      myChallengeStatus  
-  ]);
+  }, [page, pageSize, keyword, filters.categories, filters.docType, filters.status, myChallengeStatus]);
 
   useEffect(() => {
     getChallengesData();
-}, [getChallengesData, myChallengeStatus]);
+  }, [getChallengesData, myChallengeStatus]);
 
   useEffect(() => {
     setPage(1);
   }, [filters, keyword]);
-
-  useEffect(() => {
-    const handleResize = () => {
-      const width = window.innerWidth;
-      if (width > 375) {
-        setPageSize(5);
-      } else {
-        setPageSize(4);
-      }
-    };
-
-    handleResize();
-    window.addEventListener("resize", handleResize);
-
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, []);
 
   const applyFilters = useCallback(({ fields, docType, status }) => {
     setFilters({

--- a/src/lib/api/challenge-api/searchChallenge.js
+++ b/src/lib/api/challenge-api/searchChallenge.js
@@ -1,8 +1,7 @@
-
 "use server";
 
-import { API_URL } from '@/constant/constant';
-import { cookies } from 'next/headers';
+import { API_URL } from "@/constant/constant";
+import { cookies } from "next/headers";
 
 // accessToken을 안전하게 추출
 const getAccessToken = async () => {
@@ -21,8 +20,11 @@ const getAuthHeaders = async () => {
 };
 
 // 챌린지 목록 가져오기
-export async function getChallenges({ page = 1, pageSize = 4, category, docType, keyword, myChallengeStatus}) {
+export async function getChallenges({ page = 1, pageSize = 4, category, docType, keyword, status, myChallengeStatus }) {
   const headers = await getAuthHeaders();
+
+  //디버깅
+  console.log("status", status);
 
   const params = new URLSearchParams();
   params.set("page", page);
@@ -33,24 +35,30 @@ export async function getChallenges({ page = 1, pageSize = 4, category, docType,
     const cleanedKeyword = keyword.replace(/\s+/g, "");
     params.set("keyword", cleanedKeyword);
   }
+  if (status) params.set("status", status);
+  //   if (status) {
+  //   if (Array.isArray(status)) {
+  //     status.forEach((s) => params.append("status", s));
+  //   } else {
+  //     params.set("status", status);
+  //   }
+  // }
 
-
-    try {
+  try {
     let url = myChallengeStatus
       ? `${API_URL}/users/me/challenges?myChallengeStatus=${myChallengeStatus}&${params.toString()}`
       : `${API_URL}/challenges?${params.toString()}`;
 
     const res = await fetch(url, {
       method: "GET",
-      headers, // ✅ headers 추가
-      credentials: "include" // 필요하다면
+      headers,
+      credentials: "include"
     });
 
     if (!res.ok) throw new Error("챌린지 목록을 가져올 수 없습니다.");
     return res.json();
   } catch (error) {
-    console.error("🚨 서버 액션 - 챌린지 목록 오류", error);
+    console.error("서버 액션 - 챌린지 목록 오류", error);
     throw error;
   }
 }
-


### PR DESCRIPTION
챌린지 목록>필터 시 상태(진행중/마감) 오류 수정

- 기존 상태
페이지네이션에 걸려서 1페이지에서 마감된 챌린지 카드만 보여줌 
(1페이지는 마감된 챌린지 2개, 2페이지는 0개, 3페이지는 3개... 이런식)

- 수정 후
전체 데이터에서 마감된 챌린지를 페이지네이션하여 보여줌