### PR TITLE
fixed: 챌린지 검색 시 카테고리 필터 중복 가능하도록 수정

### DIFF
--- a/src/app/(user)/challenges/page.jsx
+++ b/src/app/(user)/challenges/page.jsx
@@ -27,15 +27,6 @@ function Page() {
   //현재 사용자가 일반유저인지, 관리자인지 확인
   const isAdmin = user?.role === "ADMIN";
 
-  //디버깅
-  if (isAdmin) {
-    console.log("관리자");
-  } else if (user?.role === "USER") {
-    console.log("일반 유저");
-  } else {
-    console.log("로그인 필요");
-  }
-
   const {
     challenges,
     totalCount,

--- a/src/components/card/Card.jsx
+++ b/src/components/card/Card.jsx
@@ -90,9 +90,6 @@ export default function ChallengeCard({
     }
   };
 
-  //디버깅
-  console.log("status", status);
-
   return (
     <div
       className={`flex flex-col ${variant === "simple" ? "h-auto justify-start" : "h-[227px] justify-between sm:h-[262px] md:h-[225px]"} ${variant === "simple" ? "" : "rounded-[12px] border-2 border-[var(--color-gray-800)]"} bg-white p-4`}

--- a/src/hooks/useChallengeList.js
+++ b/src/hooks/useChallengeList.js
@@ -36,7 +36,7 @@ const useChallenges = (myChallengeStatus = "") => {
         page,
         pageSize,
         keyword,
-        category: filters.categories[0] || "",
+        category: filters.categories,
         docType: filters.docType,
         status: filters.status,
         myChallengeStatus
@@ -69,12 +69,19 @@ const useChallenges = (myChallengeStatus = "") => {
     }
   }, [user, page, pageSize, keyword, categories, docType, status]);
 
+  //에러 해결해야함
   // useEffect(() => {
   //   console.log("user or getChallengesData changed", user, getChallengesData);
   //    if (!user) return; // 로그인 안 되어 있으면 실행 X
   //   getChallengesData();
 
   // }, [getChallengesData, myChallengeStatus]);
+
+  //에러 해결 전까진 임시로 챌린지 목록 불러오려고 사용중
+  //목록 정상적으로 불러와지면 지워도 됨
+  useEffect(() => {
+    getChallengesData();
+  }, [filters, keyword]);
 
   useEffect(() => {
     setPage(1);

--- a/src/lib/api/challenge-api/searchChallenge.js
+++ b/src/lib/api/challenge-api/searchChallenge.js
@@ -20,33 +20,27 @@ const getAuthHeaders = async () => {
 };
 
 // 챌린지 목록 가져오기
-
 export async function getChallenges({ page = 1, pageSize = 4, category, docType, keyword, status, myChallengeStatus }) {
-
   const headers = await getAuthHeaders();
-
-  //디버깅
-  console.log("status", status);
 
   const params = new URLSearchParams();
   params.set("page", page);
   params.set("pageSize", pageSize);
 
-  if (category) params.set("category", category);
+  if (category) {
+    //다중 쿼리 파라미터를 보낼 수 있도록
+    if (Array.isArray(category)) {
+      category.forEach((cat) => params.append("category", cat));
+    } else {
+      params.set("category", category);
+    }
+  }
   if (docType) params.set("docType", docType);
   if (keyword) {
     const cleanedKeyword = keyword.replace(/\s+/g, "");
     params.set("keyword", cleanedKeyword);
   }
   if (status) params.set("status", status);
-  //   if (status) {
-  //   if (Array.isArray(status)) {
-  //     status.forEach((s) => params.append("status", s));
-  //   } else {
-  //     params.set("status", status);
-  //   }
-  // }
-
 
   const isMyChallenge = typeof myChallengeStatus === "string" && myChallengeStatus.trim() !== "";
 
@@ -55,7 +49,6 @@ export async function getChallenges({ page = 1, pageSize = 4, category, docType,
   if (isMyChallenge) {
     params.set("myChallengeStatus", myChallengeStatus);
   }
-
 
   const url = `${API_URL}${path}?${params.toString()}`;
 
@@ -76,7 +69,6 @@ export async function getChallenges({ page = 1, pageSize = 4, category, docType,
       return { data: [], totalCount: 0 };
     }
 
-
     return {
       data: Array.isArray(json?.data) ? json.data : [],
       totalCount: typeof json?.totalCount === "number" ? json.totalCount : 0
@@ -86,4 +78,3 @@ export async function getChallenges({ page = 1, pageSize = 4, category, docType,
     throw error;
   }
 }
-


### PR DESCRIPTION
- 기존 코드
챌린지 검색 시 쿼리로 받는 filters.category가 
filters.category[0] || "" 이었기 때문에 1가지 밖에 전달이 안되고 있었음
(백엔드도 마찬가지)

- 수정된 코드
categories 배열로 받게 하고 배열로 받은 모든 카테고리를 쿼리로 넘겨줌
...&category=Next.js&category=Morder.js 이런식으로 다중 쿼리가 가능하도록 수정
(백엔드도 마찬가지로 수정함)