### PR TITLE
feat: 작업물 작성자가 작성자면서 어드민일시, 어드민 드롭다운을 우선순위로 렌더링

### DIFF
--- a/src/app/(user)/challenges/[challengeId]/work/[workId]/_components/Header.jsx
+++ b/src/app/(user)/challenges/[challengeId]/work/[workId]/_components/Header.jsx
@@ -109,7 +109,7 @@ export default function Header() {
     <div>
       <div className="mt-10 flex justify-between">
         <div className="mb-4 text-xl font-semibold text-gray-800 md:text-2xl">{challenge?.title || "Loading..."}</div>
-        {isAuthor && <Menu onEdit={handleEdit} onDelete={handleDelete} />}
+        {!isAdmin && isAuthor && <Menu onEdit={handleEdit} onDelete={handleDelete} />}
         {isAdmin && <Menu onEdit={handleEdit} onDelete={handleAdminDelete} />}
       </div>
       <div className="flex items-center gap-2">


### PR DESCRIPTION
작성자와 어드민이라는 역할이 겹쳐서 작성자이자 어드민일경우, isAuthor 조건절을 비활성화 하는 로직추가(어드민 드롭다운을 우선순위로 부여)했습니다.

- 결과 스크린샷
![image](https://github.com/user-attachments/assets/200ba2c9-bcb2-4c6b-8fc4-ac135cfe61a5)
로그인한 사용자는 ADMIN이며 동시에 작성자이기도 해서 드롭다운이 2개 렌더링되는 오류가 있었습니다.
ADMIN 일시 작성자 드롭다운은 나타나지 않게 로직을 개선했습니다. (어드민 권한우선)