### PR TITLE
fix: 유저>챌린지 목록 조회 시 승인된 챌린지만 볼 수 있도록 수정

### DIFF
--- a/src/app/(user)/challenges/page.jsx
+++ b/src/app/(user)/challenges/page.jsx
@@ -42,6 +42,19 @@ function Page() {
     applyFilters
   } = useChallenges(); // 훅 내부에서 enabled로 조건 제어
 
+  //디버깅
+  console.log("isAdmin", isAdmin);
+
+  // useEffect(() => {
+  //   if (!authLoading && user) {
+  //     if (isAdmin) {
+  //       setAdminStatus(""); //어드민이면 adminStatus에 상관없이 모든 챌린지가 보임
+  //     } else {
+  //       setAdminStatus("ACCEPTED"); //일반 유저라면 asminStatus=accepted인 챌린지만 보임
+  //     }
+  //   }
+  // }, [user, authLoading, s]);
+
   const handleClickFilter = () => {
     setIsModal(true);
   };
@@ -89,6 +102,10 @@ function Page() {
         ) : challenges.length > 0 ? (
           challenges.map((challenge) => (
             <div key={challenge.id}>
+              {
+                //디버깅
+                console.log("challenge.application.adminStatus", challenge.application.adminStatus)
+              }
               <ChallengeCard
                 onClick={() => handleClickCard(challenge.id)}
                 title={challenge.title}
@@ -97,7 +114,6 @@ function Page() {
                 deadline={challenge.deadline}
                 participants={challenge.participants.length}
                 maxParticipant={challenge.maxParticipant}
-                // status={challenge.status}
                 isAdmin={isAdmin}
               />
             </div>

--- a/src/hooks/useChallengeList.js
+++ b/src/hooks/useChallengeList.js
@@ -37,9 +37,6 @@ const useChallenges = (myChallengeStatus) => {
         status: filters.status
       };
 
-      //디버깅
-      console.log("keyword", keyword);
-
       const challengesResults = await getChallenges(options, myChallengeStatus);
       setTotalCount(challengesResults.totalCount);
 

--- a/src/lib/api/challenge-api/searchChallenge.js
+++ b/src/lib/api/challenge-api/searchChallenge.js
@@ -20,7 +20,10 @@ const getAuthHeaders = async () => {
 };
 
 // 챌린지 목록 가져오기
-export async function getChallenges({ page = 1, pageSize = 4, category, docType, keyword, status }, myChallengeStatus) {
+export async function getChallenges(
+  { page = 1, pageSize = 4, category, docType, keyword, status, adminStatus },
+  myChallengeStatus
+) {
   const headers = await getAuthHeaders();
 
   const params = new URLSearchParams();
@@ -39,9 +42,6 @@ export async function getChallenges({ page = 1, pageSize = 4, category, docType,
   if (keyword) {
     const cleanedKeyword = keyword.replace(/\s+/g, "");
 
-    //디버깅
-    console.log('cleanedKeyword', cleanedKeyword)
-    
     params.set("keyword", cleanedKeyword);
   }
   if (status) params.set("status", status);
@@ -52,6 +52,10 @@ export async function getChallenges({ page = 1, pageSize = 4, category, docType,
 
   if (isMyChallenge) {
     params.set("myChallengeStatus", myChallengeStatus);
+  }
+
+  if (adminStatus) {
+    params.set("adminStatus", adminStatus);
   }
 
   const url = `${API_URL}${path}?${params.toString()}`;
@@ -77,7 +81,7 @@ export async function getChallenges({ page = 1, pageSize = 4, category, docType,
       return { data: [], totalCount: 0 };
     }
 
-    console.log("📦 응답 데이터:", json);
+    console.log("📦 응답 데이터요:", json);
 
     return {
       data: Array.isArray(json?.data) ? json.data : [],


### PR DESCRIPTION
- 기존 코드
챌린지 목록 페이지 조회 시 관리자의 승인을 받지 못한 챌린지들 (거절, 삭제, 대기중)도 조회가 가능함

- 수정된 코드
챌린지 목록 페이지 조회 시 관리자의 승인을 받은 챌린지만(승인) 조회가 가능하게 함
쿼리 스트링에 adminStatus="ACCEPTED"를 추가하여 데이터를 불러올 수 있도록 함 