### PR TITLE
fix: 챌린지 신청 Base UrL 분기처리

### DIFF
--- a/src/lib/api/challenge-api/createChallenge.js
+++ b/src/lib/api/challenge-api/createChallenge.js
@@ -1,5 +1,6 @@
 //챌린지 생성 페이지에서 사용되는 fetch 입니다.
-const BASE_URL = "http://localhost:8080/challenges";
+// const BASE_URL = "http://localhost:8080/challenges";
+import { BASE_URL } from "@/constant/constant";
 
 //챌린지 신청하기
 export async function postChallenges(data) {
@@ -15,7 +16,7 @@ export async function postChallenges(data) {
     docType
   };
 
-  const res = await fetch(BASE_URL, {
+  const res = await fetch(`${BASE_URL}/challenges`, {
     method: "post",
     headers: {
       "Content-type": "application/json"


### PR DESCRIPTION
- 기존 코드
요청 보내는 url이 8080 으로 하드코딩 되어있던 상태

- 수정된 코드 
챌린지 신청 Base UrL constant 파일에서 분기처리