### PR TITLE
fix: 작업물 상세보기 HTML 렌더링 및 XSS 방어 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@tailwindcss/typography": "^0.5.16",
         "@tanstack/react-query": "^5.76.1",
         "@tanstack/react-query-devtools": "^5.76.1",
         "@tiptap/extension-bullet-list": "^2.12.0",
@@ -24,6 +25,7 @@
         "axios": "^1.9.0",
         "cookie-parser": "^1.4.7",
         "dayjs": "^1.11.13",
+        "dompurify": "^3.2.6",
         "hangul-js": "^0.2.6",
         "jose": "^6.0.11",
         "next": "15.3.2",
@@ -1354,6 +1356,20 @@
         "tailwindcss": "4.1.6"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
+      "integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.76.0",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.76.0.tgz",
@@ -1864,6 +1880,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "optional": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -3023,6 +3045,17 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -3206,6 +3239,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -5425,11 +5466,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -6102,6 +6152,18 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/prelude-ls": {
@@ -7308,7 +7370,6 @@
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.6.tgz",
       "integrity": "sha512-j0cGLTreM6u4OWzBeLBpycK0WIh8w7kSwcUsQZoGLHZ7xDTdM69lN64AgoIEEwFi0tnhs4wSykUa5YWxAzgFYg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -7694,6 +7755,11 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@tailwindcss/typography": "^0.5.16",
     "@tanstack/react-query": "^5.76.1",
     "@tanstack/react-query-devtools": "^5.76.1",
     "@tiptap/extension-bullet-list": "^2.12.0",
@@ -25,6 +26,7 @@
     "axios": "^1.9.0",
     "cookie-parser": "^1.4.7",
     "dayjs": "^1.11.13",
+    "dompurify": "^3.2.6",
     "hangul-js": "^0.2.6",
     "jose": "^6.0.11",
     "next": "15.3.2",

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,5 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: ["@tailwindcss/postcss"]
 };
 
 export default config;

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,4 +1,3 @@
-// prettier.config.mjs
 export default {
   plugins: ["prettier-plugin-tailwindcss"],
   printWidth: 120,

--- a/src/app/(user)/challenges/[challengeId]/work/[workId]/_components/Content.jsx
+++ b/src/app/(user)/challenges/[challengeId]/work/[workId]/_components/Content.jsx
@@ -1,4 +1,5 @@
 "use client";
+
 import Image from "next/image";
 import React, { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
@@ -8,13 +9,13 @@ import profile from "@/assets/img/profile_member.svg";
 import adminProfile from "@/assets/img/profile_admin.svg";
 import empty from "@/assets/img/empty.svg";
 import { getWorkDetailAction, createWorkLikeAction, deleteWorkLikeAction } from "@/lib/actions/work";
+import DOMPurify from "dompurify"; // ✅ 추가
 
 export default function Content() {
   const { challengeId, workId } = useParams();
   const [work, setWork] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  // 작업물 조회
   const fetchWork = async () => {
     setIsLoading(true);
     try {
@@ -32,7 +33,6 @@ export default function Content() {
     }
   };
 
-  // 좋아요 토글 핸들러
   const handleLikeToggle = async () => {
     try {
       if (work?.isLiked) {
@@ -40,21 +40,17 @@ export default function Content() {
       } else {
         await createWorkLikeAction(workId);
       }
-      await fetchWork(); // 상태 갱신
+      await fetchWork();
     } catch (error) {
       console.error("좋아요 처리 실패:", error);
       alert(error.message || "좋아요 처리 중 오류가 발생했습니다.");
     }
   };
 
-  // 날짜 포맷팅
   const formatDate = (dateString) => {
     if (!dateString) return "";
     const date = new Date(dateString);
-    return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, "0")}.${String(date.getDate()).padStart(
-      2,
-      "0"
-    )}`;
+    return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, "0")}.${String(date.getDate()).padStart(2, "0")}`;
   };
 
   useEffect(() => {
@@ -96,8 +92,14 @@ export default function Content() {
         </div>
         <div className="text-sm font-medium text-gray-500">{work?.createdAt ? formatDate(work.createdAt) : "날짜"}</div>
       </div>
+
       <div className="mb-6 border-b border-gray-200 pb-10">
-        {work?.content || (
+        {work?.content?.trim() ? (
+          <div
+            className="prose prose-sm max-w-none text-gray-900"
+            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(work.content) }}
+          />
+        ) : (
           <div className="flex flex-col items-center justify-center gap-4 py-30 text-base text-gray-900">
             <Image src={empty} width={320} height={168} alt="empty" />
             아직 아무런 번역을 진행하지 않았어요!

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -109,4 +109,18 @@
     list-style-type: decimal;
     padding-left: 1.25rem;
   }
+
+  .prose ul {
+    list-style-type: disc;
+    padding-left: 1.25rem;
+  }
+
+  .prose ol {
+    list-style-type: decimal;
+    padding-left: 1.25rem;
+  }
+
+  .prose li {
+    margin-bottom: 0.25rem;
+  }
 }

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,0 +1,8 @@
+import typography from "@tailwindcss/typography";
+
+/** @type {import('tailwindcss').Config} */
+const config = {
+  plugins: [typography]
+};
+
+export default config;


### PR DESCRIPTION
## ✨ 주요 변경 사항
![image](https://github.com/user-attachments/assets/5d786902-1f2b-46ec-8b7c-c5442b74c53a)


### 1. HTML 문자열 렌더링 기능 구현
- 서버에서 내려오는 작업물 본문(`work.content`)은 HTML 문자열 형태로 제공됨
- 이를 렌더링 화면에서 `dangerouslySetInnerHTML`을 통해 출력하도록 수정
- Tailwind Typography 플러그인(`prose`)을 적용하여 마크업 요소 스타일 자동 적용

### 2. XSS 보안 강화
- `DOMPurify.sanitize()` 적용하여 악의적인 `<script>`, `onerror`, `javascript:` 등 제거
- 클라이언트 측에서도 안전하게 콘텐츠 렌더링

### 3. 리스트(`ul`, `ol`) 스타일 보정
- 출력 화면에서 불릿(`•`)과 숫자(`1.`)가 보이지 않던 문제 해결
- Tailwind 유틸리티(`list-disc`, `list-decimal`, `list-inside`) 적용
- Typography 플러그인의 기본 스타일이 마커를 숨기고 있어 유틸로 명시 보정

### 4. 기타
- 에디터 내부에서는 `.ProseMirror ul/ol`에 대한 스타일 이미 존재하므로 출력용에서만 추가 처리

---

## 📁 관련 파일

- `components/Content.jsx`: 작업물 렌더링 영역
- `styles/globals.css`: typography 기본 스타일 정의 및 커스텀
- `tailwind.config.ts`: `@tailwindcss/typography` 플러그인 적용

---

## 🛡 테스트

- ✅ 다양한 HTML 입력 (h1, p, ul, ol 등) 정상 렌더링
- ✅ XSS 의심 코드 (`<script>`, `onerror`, `onclick`) 필터링 확인
- ✅ 리스트 마커 정상 출력 확인

---

## 📌 참고

- Tailwind Typography 플러그인은 Tailwind core 스타일과 충돌 시 의도치 않게 list-style을 제거할 수 있음
- prose 클래스는 `.prose ul/ol` 에 마커 스타일을 주지 않기 때문에 유틸리티를 직접 적용하거나 스타일을 override 해야 함
