### PR TITLE
fix: 챌린지수정 엔드포인트 주소 개선

### DIFF
--- a/src/components/card/Card.jsx
+++ b/src/components/card/Card.jsx
@@ -68,7 +68,7 @@ export default function ChallengeCard({
   };
 
   const handleEdit = () => {
-    router.push(`/admin/challenges/${challengeId}/edit`);
+    router.push(`/challenges/${challengeId}/edit`); // 챌린지수정 라우터에 adminValidator 존재, 어드민-유저가 동일한 엔드포인트 사용 가능
     setIsDropdownOpen(false);
   };
 
@@ -93,16 +93,16 @@ export default function ChallengeCard({
 
   const btnProps = isComplete
     ? {
-        theme: "solidwhite",
-        iconType: "goToMyWork",
-        text: "내 작업물 보기"
-      }
+      theme: "solidwhite",
+      iconType: "goToMyWork",
+      text: "내 작업물 보기"
+    }
     : isMy
       ? {
-          theme: "outline",
-          iconType: "continueChallenge",
-          text: "도전 계속하기"
-        }
+        theme: "outline",
+        iconType: "continueChallenge",
+        text: "도전 계속하기"
+      }
       : null;
 
   return (
@@ -120,6 +120,7 @@ export default function ChallengeCard({
           </button>
         </div>
 
+        {/* 어드민 드롭다운(수정,삭제) */}
         {isAdmin ? (
           <div ref={dropdownRef}>
             <button onClick={() => setIsDropdownOpen(!isDropdownOpen)}>

--- a/src/components/reply/Reply.jsx
+++ b/src/components/reply/Reply.jsx
@@ -71,8 +71,8 @@ export default function Reply({
           </div>
         </div>
 
-        {/* isAuthor가 true일 때만 메뉴/수정 버튼 표시 */}
-        {isAuthor && !isEditMode ? (
+        {/* isAdmin이 false이면서 isAuthor가 true일때만 메뉴/수정 버튼 표시 */}
+        {!isAdmin && isAuthor && !isEditMode ? (
           <div className="relative" ref={menuRef}>
             <button
               onClick={handleMoreClick}
@@ -111,7 +111,7 @@ export default function Reply({
             </button>
           </div>
         ) : null}
-        {/* isAuthor가 true일 때만 메뉴/수정 버튼 표시 */}
+        {/* isAdmin가 true일 때만 메뉴/수정 버튼 표시 */}
         {isAdmin && !isEditMode ? (
           <div className="relative" ref={menuRef}>
             <button


### PR DESCRIPTION
챌린지수정 엔드포인트 주소 개선했습니다.

작업내용:
- 어드민 챌린지수정시 `/challenges/:challengeId/edit` 로 이동
- 피드백에서 관리자 드롭다운 렌더링 조건 `!isAdmin && isAuthor && !isEditMode`로 개선 (작성자,관리자 드롭다운이 겹치는 현상 개선