### PR TITLE
스크롤 overflow를 auto로 설정 & 챌린지관리페이지에 로딩spinner 적용

### DIFF
--- a/src/app/(user)/challenges/my/apply/_components/AppliedChallenges.jsx
+++ b/src/app/(user)/challenges/my/apply/_components/AppliedChallenges.jsx
@@ -12,7 +12,7 @@ export default function AppliedChallenges({ resultData, totalCount, page, pageSi
 
   return (
     <>
-      <div className="overflow-scroll">
+      <div className="overflow-auto">
         <ListHead />
         <div>
           {resultData?.map((data) => (

--- a/src/app/admin/management/page.jsx
+++ b/src/app/admin/management/page.jsx
@@ -7,6 +7,7 @@ import Sort from "@/components/sort/Sort";
 import { ITEM_COUNT } from "@/constant/constant";
 import { adminService } from "@/lib/service/adminService";
 import { useEffect, useState } from "react";
+import LoadingSpinner from "@/components/loading/LoadingSpinner";
 
 export default function AdminManagementPage() {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -16,9 +17,11 @@ export default function AdminManagementPage() {
   const [selectedSortLabel, setSelectedSortLabel] = useState("신청 시간 느린순");
   const [sort, setSort] = useState("appliedAt_desc");
   const [keyword, setKeyword] = useState("");
+  const [isLoading, setIsLoading] = useState(true)
   const pageSize = ITEM_COUNT.APPLICATION;
 
   const fetchApplications = async () => {
+    setIsLoading(true);
     try {
       const { totalCount, applications } = await adminService.getApplications(page, pageSize, sort, keyword);
       setApplications(applications);
@@ -26,6 +29,8 @@ export default function AdminManagementPage() {
     } catch (err) {
       console.error("신청 목록 조회 실패:", err.message);
       alert(err.message);
+    } finally {
+      setIsLoading(false)
     }
   };
 
@@ -50,13 +55,19 @@ export default function AdminManagementPage() {
           {isDropdownOpen && <ApplyDropdown onSelect={handleSortSelect} className="absolute right-0 mt-2" />}
         </div>
       </div>
-      <AppliedChallenges
-        resultData={applications}
-        totalCount={totalCount}
-        page={page}
-        pageSize={pageSize}
-        onPageChange={(newPage) => setPage(newPage)}
-      />
+      {isLoading ? (
+        <div className="flex justify-center items-center h-[300px]">
+          <LoadingSpinner />
+        </div>
+      ) : (
+        <AppliedChallenges
+          resultData={applications}
+          totalCount={totalCount}
+          page={page}
+          pageSize={pageSize}
+          onPageChange={(newPage) => setPage(newPage)}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
스크롤 overflow를 auto로 설정했습니다.

- 일반적인 크기에서는 스크롤이 드러나지 않게 되며,
![image](https://github.com/user-attachments/assets/041d656c-f7cc-4a88-a545-53aa895be9fc)

- 크기가 작아지면 스크롤이 나타날 수도 있게 됩니다( overflow auto 설정 )
![image](https://github.com/user-attachments/assets/d67b79ea-9831-40c5-aef6-70c685ee9fd7)

---

- 챌린지관리페이지에 스피너 적용했습니다.
![image](https://github.com/user-attachments/assets/1242c866-3a83-4f51-ac27-2847bf09636e)
