### PR TITLE
feat: 작업물 소프트 삭제 Header.jsx에서 로직 변경 및 해당 함수 (어드민) 추가

### DIFF
--- a/src/app/(user)/challenges/[challengeId]/work/[workId]/_components/Header.jsx
+++ b/src/app/(user)/challenges/[challengeId]/work/[workId]/_components/Header.jsx
@@ -12,7 +12,7 @@ import Menu from "./Menu";
 import { useAuth } from "@/providers/AuthProvider";
 import { getWorkDetailAction, deleteWorkAction } from "@/lib/actions/work";
 import DeclineModal from "@/components/modal/DeclineModal";
-import { deleteChallengeAction } from "@/lib/actions/admin";
+import { deleteWorkAdminAction } from "@/lib/actions/admin";
 
 const categoryComponentMap = {
   "Next.js": NextjsChip,
@@ -77,7 +77,7 @@ export default function Header() {
   // 삭제 (Server Action 활용)
   const handleDelete = async () => {
     try {
-      await deleteWorkAction(workId);
+      await deleteWorkAdminAction(workId, deletionReason);
       // 삭제 성공 시, 해당 챌린지 페이지로 이동
       router.push(`/challenges/${challengeId}`);
     } catch (error) {
@@ -96,7 +96,7 @@ export default function Header() {
 
   const handleConfirmDelete = async (adminMessage) => {
     try {
-      await deleteChallengeAction(challengeId, adminMessage);
+      await deleteWorkAction(workId, adminMessage);
       // 삭제 성공 시, 해당 챌린지 페이지로 이동
       router.push(`/challenges/${challengeId}`);
     } catch (error) {

--- a/src/lib/actions/admin.js
+++ b/src/lib/actions/admin.js
@@ -155,3 +155,48 @@ export async function updateChallengeAction(challengeId, updatedData) {
 
   return res.json();
 }
+
+// 어드민 - 작업물 소프트 삭제
+/* 
+### 작업물 소프트삭제 (작업물 비활성화 필드 true)
+PATCH http://localhost:8080/admin/works/4
+Cookie: accessToken={{accessToken}}
+Content-Type: application/json
+
+{
+  "deletionReason": "사용자 요청에 의한 삭제 사유456"
+}
+*/
+export async function deleteWorkAdminAction(workId, deletionReason) {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("accessToken")?.value;
+
+  const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+  if (!accessToken) {
+    throw new Error("인증되지 않았습니다: 액세스 토큰이 없습니다.");
+  }
+
+  try {
+    const response = await fetch(`${API_URL}/admin/works/${workId}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `accessToken=${accessToken}`
+      },
+      body: JSON.stringify({
+        deletionReason: deletionReason
+      })
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.message || "작업물 삭제에 실패했습니다.");
+    }
+
+    return await response.json();
+  } catch (err) {
+    console.error("서버 액션 - 작업물 삭제 오류:", err);
+    throw err;
+  }
+}


### PR DESCRIPTION
작업물 소프트 삭제 Header.jsx에서 로직 변경 및 해당 함수 (어드민) 추가했습니다.

- 어드민으로 로그인 시 타인의 작업물 삭제 수행하고 작업물이 챌린지에서 제거됩니다.

---

![image](https://github.com/user-attachments/assets/3e2e9c95-c863-41ef-baef-46757834c851)

deleteWorkAdminAction 이라는 서버액션 함수 만들어서 사용했어요.
