### PR TITLE
feat: 어드민 신청 상세 승인된 챌린지 iframe 추가

### DIFF
--- a/src/app/admin/management/[id]/page.jsx
+++ b/src/app/admin/management/[id]/page.jsx
@@ -111,6 +111,17 @@ export default function AdminApplicationPage() {
         </div>
       )}
       {isModalOpen && <DeclineModal onClose={() => setisModalOpen(false)} onConfirm={handleConfirmDecline} />}
+      {application?.adminStatus === "ACCEPTED" && (
+        <iframe
+          src={`/challenges/${challenge.id}`}
+          title="원문 페이지"
+          className="mt-8 h-full w-full border-0"
+          style={{ height: "calc(100vh - 200px)" }}
+          loading="lazy"
+          allow="clipboard-read; clipboard-write"
+          sandbox="allow-same-origin allow-scripts allow-popups allow-forms"
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### 어드민 신청 관리 상세 페이지에서 승인된 챌린지의 경우 iframe으로 해당 챌린지 조회 가능하게 수정했습니다.
<img width="1036" alt="image" src="https://github.com/user-attachments/assets/e0dec885-f980-45d5-b0d1-940be7021144" />
